### PR TITLE
feat(ui): add resizable table columns and improve cell styling

### DIFF
--- a/cmd/gui/frontend/src/components/CellContent.tsx
+++ b/cmd/gui/frontend/src/components/CellContent.tsx
@@ -53,7 +53,7 @@ export function CellContent({
     <Popover open={isHovered} onOpenChange={setIsHovered}>
       <PopoverTrigger asChild>
         <div
-          className="text-sm truncate hover:underline hover:bg-accent/50 -mx-4 px-4 -my-2 py-2 rounded cursor-pointer"
+          className="text-sm overflow-hidden whitespace-nowrap hover:underline hover:bg-accent/50 rounded cursor-pointer"
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
           onClick={handleClick}


### PR DESCRIPTION
## Summary
- Enable column resizing with drag handles on header borders
- Dynamic maxSize per column based on header/value length (no more hardcoded 300px)
- Header style changed to muted foreground
- Cell content overflow hidden without ellipsis ("..." removed)
- Fix row border to fill full width when columns are narrower than viewport
- Remove hover effect overflow from cell boundaries

## Test plan
- [x] Verify column resize handles appear on header borders
- [x] Drag to resize columns and confirm maxSize respects actual content length
- [x] Check header text is muted style
- [x] Confirm cell hover effect stays within cell boundaries
- [x] Verify row borders extend full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)