### PR TITLE
feat(gui): add pulse animation to CTA buttons for better visibility

### DIFF
--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -243,10 +243,10 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
                 <div className="h-full flex items-center justify-center px-4">
                   <Button
                     variant="ghost"
-                    className="text-sm text-muted-foreground flex items-center gap-1 hover:text-foreground"
+                    className="text-sm flex items-center gap-1 rounded-lg px-4 py-2 animate-cta-pulse"
                     onClick={() => setShowCommandPalette(true)}
                   >
-                    Press <Kbd>⌘</Kbd><Kbd>K</Kbd> to select a resource
+                    Press <Kbd>⌘</Kbd><Kbd>K</Kbd> to show schema fields
                   </Button>
                 </div>
               )}
@@ -282,7 +282,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
               <div className="h-full flex items-center justify-center px-4">
                 <Button
                   variant="ghost"
-                  className="text-sm text-muted-foreground flex items-center gap-1 hover:text-foreground"
+                  className="text-sm flex items-center gap-1 rounded-lg px-4 py-2 animate-cta-pulse"
                   onClick={() => setShowCommandPalette(true)}
                 >
                   Press <Kbd>⌘</Kbd><Kbd>K</Kbd> to select a resource

--- a/cmd/gui/frontend/src/style.css
+++ b/cmd/gui/frontend/src/style.css
@@ -85,3 +85,25 @@
     }
 }
 
+/* CTA pulse animation for visibility */
+@keyframes cta-pulse {
+  0%, 100% {
+    background-color: hsl(var(--accent) / 0.15);
+    color: hsl(var(--accent));
+  }
+  50% {
+    background-color: hsl(var(--accent) / 0.25);
+    color: hsl(var(--accent-foreground));
+  }
+}
+
+.animate-cta-pulse {
+  animation: cta-pulse 2s ease-in-out infinite;
+}
+
+.animate-cta-pulse:hover {
+  animation: none;
+  background-color: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+


### PR DESCRIPTION
## Summary
- Add `cta-pulse` CSS animation with accent color background for empty state CTA buttons
- Apply animation to both nav panel and main area buttons
- Animation stops on hover with solid accent background
- Change nav panel text from "to select a resource" to "to show schema fields"

## Test plan
- [x] Verify CTA buttons pulse with accent color when no resource is selected
- [x] Verify animation stops on hover
- [x] Verify nav panel shows correct text "Press ⌘K to show schema fields"

🤖 Generated with [Claude Code](https://claude.com/claude-code)