### PR TITLE
fix(gui): use resolvedTheme for correct theme toggle behavior

### DIFF
--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -36,12 +36,12 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
   const sidebarPanelRef = useRef<ImperativePanelHandle>(null);
   const navigationPanelRef = useRef<NavigationPanelHandle>(null);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, resolvedTheme } = useTheme();
 
   // Handle theme toggle with animation
   const handleThemeToggle = useCallback((event: React.MouseEvent | React.KeyboardEvent) => {
-    toggleThemeWithAnimation(event, theme, setTheme);
-  }, [theme, setTheme]);
+    toggleThemeWithAnimation(event, resolvedTheme, setTheme);
+  }, [resolvedTheme, setTheme]);
 
   // Convert selectedFields to Set<string> for favorite comparison
   const selectedPaths = useMemo(() => {
@@ -300,7 +300,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
           gvks={gvks}
           favorites={allFavorites}
           loading={loading}
-          theme={theme}
+          theme={resolvedTheme}
           onClose={() => setShowCommandPalette(false)}
           onGVKSelect={(gvk) => {
             setSelectedGVK(gvk);

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -36,7 +36,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
   const sidebarPanelRef = useRef<ImperativePanelHandle>(null);
   const navigationPanelRef = useRef<NavigationPanelHandle>(null);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
 
   // Handle theme toggle with animation
   const handleThemeToggle = useCallback((event: React.MouseEvent | React.KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- Fix theme toggle not working correctly when system theme is dark on initial app launch
- Use `resolvedTheme` instead of `theme` to base toggle behavior on the actual applied theme

## Problem
When `theme` is "system" in `next-themes`:
- `theme === "dark"` evaluates to false, so toggle UI shows "Dark Mode" (even though dark mode is actually applied)
- On toggle, `"system" === 'dark'` is false, so it always switches to "light"
- "light" gets saved to localStorage, causing the app to always start in light mode afterwards

## Solution
`resolvedTheme` returns the actual applied theme ("light" or "dark") reflecting the system theme:
- Pass `resolvedTheme` to CommandPalette (correct UI display)
- Pass `resolvedTheme` to `toggleThemeWithAnimation` (correct toggle logic)

## Test plan
- [x] Remove theme from localStorage and restart app
- [x] Verify toggle button shows "Light Mode" when system is in dark mode
- [x] Verify toggle correctly switches between light/dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)