### PR TITLE
build(makefile): improve gui-release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,9 @@ gui-build-all: gui-icons
 # macOS code signing and notarization
 APP_NAME=kattle
 BUILD_BIN=$(GUI_DIR)/build/bin
+DMG_NAME=$(APP_NAME)-$(VERSION).dmg
 
-.PHONY: gui-codesign gui-dmg gui-notarize gui-staple gui-release-darwin
+.PHONY: gui-codesign gui-dmg gui-notarize gui-staple gui-release-darwin gui-release
 
 gui-codesign:
 	codesign --deep --force --verify --verbose \
@@ -46,25 +47,40 @@ gui-codesign:
 		$(BUILD_BIN)/$(APP_NAME).app
 
 gui-dmg: gui-codesign
-	rm -f $(BUILD_BIN)/$(APP_NAME).dmg
+	rm -f $(BUILD_BIN)/$(DMG_NAME)
 	rm -rf $(BUILD_BIN)/dmg-staging
 	mkdir -p $(BUILD_BIN)/dmg-staging
 	cp -R $(BUILD_BIN)/$(APP_NAME).app $(BUILD_BIN)/dmg-staging/
 	ln -s /Applications $(BUILD_BIN)/dmg-staging/Applications
 	hdiutil create -volname "$(APP_NAME)" \
 		-srcfolder $(BUILD_BIN)/dmg-staging \
-		-ov -format UDZO $(BUILD_BIN)/$(APP_NAME).dmg
+		-ov -format UDZO $(BUILD_BIN)/$(DMG_NAME)
 	rm -rf $(BUILD_BIN)/dmg-staging
 	codesign --force --sign "$(APPLE_IDENTITY)" \
-		--timestamp $(BUILD_BIN)/$(APP_NAME).dmg
+		--timestamp $(BUILD_BIN)/$(DMG_NAME)
 
 gui-notarize:
-	xcrun notarytool submit $(BUILD_BIN)/$(APP_NAME).dmg \
+	xcrun notarytool submit $(BUILD_BIN)/$(DMG_NAME) \
 		--keychain-profile "$(NOTARY_PROFILE)" \
 		--wait
 
 gui-staple:
-	xcrun stapler staple $(BUILD_BIN)/$(APP_NAME).dmg
+	xcrun stapler staple $(BUILD_BIN)/$(DMG_NAME)
 
-gui-release-darwin: gui-build-darwin gui-dmg gui-notarize gui-staple
-	@echo "Release complete: $(BUILD_BIN)/$(APP_NAME).dmg"
+gui-release-darwin:
+ifndef VERSION
+	$(error VERSION is required. Example: make gui-release-darwin VERSION=v1.0.0)
+endif
+ifndef APPLE_IDENTITY
+	$(error APPLE_IDENTITY is required. Set it to your Developer ID Application certificate name)
+endif
+ifndef NOTARY_PROFILE
+	$(error NOTARY_PROFILE is required. Set it to your notarytool keychain profile name)
+endif
+	$(MAKE) gui-build-darwin gui-dmg gui-notarize gui-staple
+	@echo "macOS release complete: $(BUILD_BIN)/$(DMG_NAME)"
+
+gui-release: gui-release-darwin gui-build-windows
+	@echo "Release complete:"
+	@echo "  macOS:   $(BUILD_BIN)/$(DMG_NAME)"
+	@echo "  Windows: $(BUILD_BIN)/$(APP_NAME).exe"


### PR DESCRIPTION
## Summary
- Add VERSION to DMG filename (e.g., `kattle-v1.0.0.dmg`)
- Add `gui-release` target for combined macOS release + Windows build
- Add required parameter checks: `VERSION`, `APPLE_IDENTITY`, `NOTARY_PROFILE`

## Usage
```bash
make gui-release VERSION=v1.0.0 APPLE_IDENTITY="Developer ID Application: ..." NOTARY_PROFILE="my-profile"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)