### PR TITLE
ci(website): add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -1,0 +1,43 @@
+name: Deploy Website to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Astro
+        uses: withastro/action@v3
+        with:
+          path: ./website
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -5,5 +5,7 @@ import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://flavono123.github.io',
+  base: '/kattle',
   integrations: [tailwind(), react()],
 });


### PR DESCRIPTION
## Summary
- Configure `astro.config.mjs` with `site` and `base` for GitHub Pages
- Add `deploy-website.yaml` workflow using `withastro/action`
- Triggers on push to main when `website/**` changes

## After merging
1. Go to **Settings** → **Pages**
2. Set **Source** to **GitHub Actions**

Deploy URL: https://flavono123.github.io/kattle

🤖 Generated with [Claude Code](https://claude.com/claude-code)