### PR TITLE
fix(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'website/**'
+      - '.github/workflows/deploy-website.yaml'
   workflow_dispatch:
 
 permissions:
@@ -12,22 +13,14 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Build with Astro
-        uses: withastro/action@v3
+      - name: Checkout your repository using git
+        uses: actions/checkout@v6
+      - name: Install, build, and upload your site output
+        uses: withastro/action@v5
         with:
           path: ./website
 

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -23,6 +23,8 @@ jobs:
         uses: withastro/action@v5
         with:
           path: ./website
+        env:
+          GITHUB_PAGES: 'true'
 
   deploy:
     needs: build

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -3,9 +3,11 @@ import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import react from '@astrojs/react';
 
+const isGitHubPages = process.env.GITHUB_PAGES === 'true';
+
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://flavono123.github.io',
-  base: '/kupid',
+  site: isGitHubPages ? 'https://flavono123.github.io' : 'https://kattle.vercel.app',
+  base: isGitHubPages ? '/kupid' : '/',
   integrations: [tailwind(), react()],
 });

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import { GITHUB_REPO } from '../config';
 const currentYear = new Date().getFullYear();
+const base = import.meta.env.BASE_URL;
 ---
 
 <footer class="border-t border-neutral-800 bg-neutral-950 py-12">
@@ -18,13 +19,13 @@ const currentYear = new Date().getFullYear();
         <a href={GITHUB_REPO} target="_blank" rel="noopener noreferrer" class="hover:text-kattle-bada transition-colors">
           GitHub
         </a>
-        <a href="/priceless" class="hover:text-kattle-chorong transition-colors">
+        <a href={`${base}priceless`} class="hover:text-kattle-chorong transition-colors">
           Price-less
         </a>
-        <a href="/changelog" class="hover:text-kattle-ari transition-colors">
+        <a href={`${base}changelog`} class="hover:text-kattle-ari transition-colors">
           Changelog
         </a>
-        <a href="/blog" class="hover:text-kattle-bada transition-colors">
+        <a href={`${base}blog`} class="hover:text-kattle-bada transition-colors">
           Blog
         </a>
       </div>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -3,6 +3,8 @@ import { Image } from 'astro:assets';
 import logoSvg from '../assets/logo.svg';
 import GitHubStars from './GitHubStars.astro';
 
+const base = import.meta.env.BASE_URL;
+
 interface NavItem {
   label: string;
   href: string;
@@ -11,16 +13,16 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
-  { label: 'Price-less', href: '/priceless', color: 'hover:text-kattle-chorong' },
-  { label: 'Changelog', href: '/changelog', color: 'hover:text-kattle-ari' },
-  { label: 'Blog', href: '/blog', color: 'hover:text-kattle-bada' },
+  { label: 'Price-less', href: `${base}priceless`, color: 'hover:text-kattle-chorong' },
+  { label: 'Changelog', href: `${base}changelog`, color: 'hover:text-kattle-ari' },
+  { label: 'Blog', href: `${base}blog`, color: 'hover:text-kattle-bada' },
 ];
 ---
 
 <header class="fixed top-0 left-0 right-0 z-50 border-b border-neutral-800 bg-neutral-950/90 backdrop-blur-xl">
   <nav class="container-narrow flex h-14 items-center justify-between">
     <!-- Logo -->
-    <a href="/" class="flex items-center gap-2 font-display text-xl font-bold">
+    <a href={base} class="flex items-center gap-2 font-display text-xl font-bold">
       <Image src={logoSvg} alt="kattle logo" class="h-6 w-auto" loading="eager" />
       <span class="kattle-gradient">kattle</span>
     </a>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -22,7 +22,7 @@ const { title, description = "Pick any field from your clusters. Kubernetes reso
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
   </head>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -5,6 +5,8 @@ import DownloadButtons from '../components/DownloadButtons.astro';
 import FeatureSection from '../components/FeatureSection.astro';
 import Footer from '../components/Footer.astro';
 import { Sparkles, Monitor } from '@lucide/astro';
+
+const base = import.meta.env.BASE_URL;
 ---
 
 <BaseLayout title="kattle - Pick any field from your clusters">
@@ -22,7 +24,7 @@ import { Sparkles, Monitor } from '@lucide/astro';
 
       <div class="container-narrow text-center py-24">
         <!-- Priceless Badge -->
-        <a href="/priceless" class="mb-8 inline-flex items-center gap-2 rounded-full border-2 border-kattle-chorong/50 bg-kattle-chorong/10 px-4 py-2 text-sm font-medium transition-colors hover:bg-kattle-chorong/20">
+        <a href={`${base}priceless`} class="mb-8 inline-flex items-center gap-2 rounded-full border-2 border-kattle-chorong/50 bg-kattle-chorong/10 px-4 py-2 text-sm font-medium transition-colors hover:bg-kattle-chorong/20">
           <Sparkles class="h-4 w-4 text-kattle-chorong" />
           <span class="text-kattle-chorong">Price-less</span>
           <span class="text-neutral-500">—</span>


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` → `@v6`
- `withastro/action@v3` → `@v5`
- Remove unnecessary `configure-pages` step
- Add workflow file itself to trigger paths

Based on the official Astro docs: https://docs.astro.build/en/guides/deploy/github/