### PR TITLE
fix(website): add trailing slash to base path

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,6 +8,6 @@ const isGitHubPages = process.env.GITHUB_PAGES === 'true';
 // https://astro.build/config
 export default defineConfig({
   site: isGitHubPages ? 'https://flavono123.github.io' : 'https://kattle.vercel.app',
-  base: isGitHubPages ? '/kupid' : '/',
+  base: isGitHubPages ? '/kupid/' : '/',
   integrations: [tailwind(), react()],
 });


### PR DESCRIPTION
## Problem
Links were being generated as `/kupidpriceless` instead of `/kupid/priceless`

## Fix
Add trailing slash to base path: `/kupid` → `/kupid/`

This makes `BASE_URL` = `/kupid/`, so `${BASE_URL}priceless` = `/kupid/priceless`