### PR TITLE
feat(gui): comprehensive keyboard navigation support

### DIFF
--- a/cmd/gui/frontend/src/components/CellContent.tsx
+++ b/cmd/gui/frontend/src/components/CellContent.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from 'react';  // For copied state
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { HighlightedText } from './HighlightedText';
 import { cn } from '@/lib/utils';
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 interface CellContentProps {
   value: any;
   highlightIndices?: [number, number][] | null;
-  /** Whether this cell is focused via keyboard navigation */
+  /** Whether this cell is focused (keyboard or mouse) */
   isFocused?: boolean;
   /** Whether to show "Copied" feedback (controlled by parent) */
   showCopied?: boolean;
@@ -18,12 +18,9 @@ export function CellContent({
   isFocused = false,
   showCopied = false,
 }: CellContentProps) {
-  const [isHovered, setIsHovered] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  // Show popover when hovered OR focused
-  const isOpen = isHovered || isFocused;
-  // Show "Copied" when clicked (hover) OR space pressed (focus)
+  // Show "Copied" when clicked OR space pressed
   const displayCopied = copied || showCopied;
 
   // Handle null/undefined
@@ -62,16 +59,14 @@ export function CellContent({
 
   // Always render with popover for consistency
   return (
-    <Popover open={isOpen} onOpenChange={setIsHovered}>
+    <Popover open={isFocused}>
       <PopoverTrigger asChild>
         <div
           className={cn(
             "text-sm overflow-hidden whitespace-nowrap rounded cursor-pointer",
-            "hover:underline hover:bg-accent/50",
+            // Same style for both keyboard and mouse focus
             isFocused && "underline bg-accent/50"
           )}
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
           onClick={handleClick}
         >
           {content}

--- a/cmd/gui/frontend/src/components/CellContent.tsx
+++ b/cmd/gui/frontend/src/components/CellContent.tsx
@@ -1,18 +1,30 @@
 import { useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { HighlightedText } from './HighlightedText';
+import { cn } from '@/lib/utils';
 
 interface CellContentProps {
   value: any;
   highlightIndices?: [number, number][] | null;
+  /** Whether this cell is focused via keyboard navigation */
+  isFocused?: boolean;
+  /** Whether to show "Copied" feedback (controlled by parent) */
+  showCopied?: boolean;
 }
 
 export function CellContent({
   value,
   highlightIndices,
+  isFocused = false,
+  showCopied = false,
 }: CellContentProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  // Show popover when hovered OR focused
+  const isOpen = isHovered || isFocused;
+  // Show "Copied" when clicked (hover) OR space pressed (focus)
+  const displayCopied = copied || showCopied;
 
   // Handle null/undefined
   if (value === null || value === undefined) {
@@ -50,10 +62,14 @@ export function CellContent({
 
   // Always render with popover for consistency
   return (
-    <Popover open={isHovered} onOpenChange={setIsHovered}>
+    <Popover open={isOpen} onOpenChange={setIsHovered}>
       <PopoverTrigger asChild>
         <div
-          className="text-sm overflow-hidden whitespace-nowrap hover:underline hover:bg-accent/50 rounded cursor-pointer"
+          className={cn(
+            "text-sm overflow-hidden whitespace-nowrap rounded cursor-pointer",
+            "hover:underline hover:bg-accent/50",
+            isFocused && "underline bg-accent/50"
+          )}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
           onClick={handleClick}
@@ -72,7 +88,7 @@ export function CellContent({
           ) : (
             fullText
           )}
-          {copied && (
+          {displayCopied && (
             <span className="ml-2 text-xs text-primary font-medium">
               Copied
             </span>

--- a/cmd/gui/frontend/src/components/CommandPalette.test.tsx
+++ b/cmd/gui/frontend/src/components/CommandPalette.test.tsx
@@ -244,7 +244,7 @@ describe('CommandPalette - Focus Management', () => {
       expect(hasTextContent('Deployment')).toBe(true);
     });
 
-    const searchInput = screen.getByPlaceholderText('Search resources...');
+    const searchInput = screen.getByPlaceholderText('Search ...');
 
     // Type "po" to filter
     await user.type(searchInput, 'po');
@@ -288,7 +288,7 @@ describe('CommandPalette - Focus Management', () => {
       expect(hasTextContent('Deployment')).toBe(true);
     });
 
-    const searchInput = screen.getByPlaceholderText('Search resources...');
+    const searchInput = screen.getByPlaceholderText('Search ...');
 
     // Type "deploy" to filter
     await user.type(searchInput, 'deploy');
@@ -324,7 +324,7 @@ describe('CommandPalette - Focus Management', () => {
       expect(hasTextContent('Pod')).toBe(true);
     });
 
-    const searchInput = screen.getByPlaceholderText('Search resources...');
+    const searchInput = screen.getByPlaceholderText('Search ...');
 
     // Type a search query
     await user.type(searchInput, 'deploy');
@@ -369,7 +369,7 @@ describe('CommandPalette - Focus Management', () => {
       expect(hasTextContent('Pod')).toBe(true);
     });
 
-    const searchInput = screen.getByPlaceholderText('Search resources...');
+    const searchInput = screen.getByPlaceholderText('Search ...');
 
     // Type a query that matches nothing
     await user.type(searchInput, 'xyz123');

--- a/cmd/gui/frontend/src/components/CommandPalette.tsx
+++ b/cmd/gui/frontend/src/components/CommandPalette.tsx
@@ -145,7 +145,7 @@ export function CommandPalette({ contexts, gvks, favorites, loading, theme, onCl
         >
           <CommandInput
             ref={searchInputRef}
-            placeholder="Search resources..."
+            placeholder="Search ..."
             value={query}
             onValueChange={setQuery}
           />

--- a/cmd/gui/frontend/src/components/ContextGallery.tsx
+++ b/cmd/gui/frontend/src/components/ContextGallery.tsx
@@ -273,7 +273,7 @@ export function ContextGallery({ onContextsConnected, onLogoClick }: ContextGall
                 <Input
                   ref={searchInputRef}
                   type="text"
-                  placeholder="Search contexts..."
+                  placeholder="Search ..."
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   onFocus={() => setIsSearchFocused(true)}

--- a/cmd/gui/frontend/src/components/FieldSearchBar.tsx
+++ b/cmd/gui/frontend/src/components/FieldSearchBar.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, useImperativeHandle, useRef } from "react";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
 import { X } from "lucide-react";
@@ -11,14 +12,26 @@ interface FieldSearchBarProps {
   onClose: () => void;
 }
 
-export function FieldSearchBar({
+export interface FieldSearchBarHandle {
+  isInputFocused: () => boolean;
+  focus: () => void;
+}
+
+export const FieldSearchBar = forwardRef<FieldSearchBarHandle, FieldSearchBarProps>(({
   query,
   onQueryChange,
   currentMatchIndex,
   totalMatches,
   hasMoreResults,
   onClose,
-}: FieldSearchBarProps) {
+}, ref) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    isInputFocused: () => document.activeElement === inputRef.current,
+    focus: () => inputRef.current?.focus(),
+  }), []);
+
   return (
     <div className="
       p-2 flex items-center gap-1.5
@@ -29,6 +42,7 @@ export function FieldSearchBar({
       md:p-1.5
     ">
       <Input
+        ref={inputRef}
         placeholder="Search ..."
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
@@ -50,4 +64,6 @@ export function FieldSearchBar({
       </Button>
     </div>
   );
-}
+});
+
+FieldSearchBar.displayName = 'FieldSearchBar';

--- a/cmd/gui/frontend/src/components/FieldSearchBar.tsx
+++ b/cmd/gui/frontend/src/components/FieldSearchBar.tsx
@@ -29,7 +29,7 @@ export function FieldSearchBar({
       md:p-1.5
     ">
       <Input
-        placeholder="Search..."
+        placeholder="Search ..."
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
         className="flex-1 h-8 text-sm"

--- a/cmd/gui/frontend/src/components/KeymapBar.tsx
+++ b/cmd/gui/frontend/src/components/KeymapBar.tsx
@@ -1,0 +1,113 @@
+import { Kbd } from './ui/kbd';
+
+export type FocusedPanel = 'nav' | 'table' | null;
+
+interface KeymapBarProps {
+  focusedPanel: FocusedPanel;
+  selectedFieldCount: number;
+  isSearchFocused: boolean;
+  hasTableData: boolean;
+}
+
+export function KeymapBar({
+  focusedPanel,
+  selectedFieldCount,
+  isSearchFocused,
+  hasTableData,
+}: KeymapBarProps) {
+  return (
+    <div className="flex-shrink-0 px-4 py-2 border-t border-border bg-muted/30 flex gap-4 text-xs text-muted-foreground">
+      {/* Common shortcuts */}
+      <div className="flex items-center gap-1">
+        <Kbd>⌘</Kbd>
+        <Kbd>K</Kbd>
+        <span>Command</span>
+      </div>
+
+      {isSearchFocused ? (
+        // Search focused shortcuts
+        <>
+          <div className="flex items-center gap-1">
+            <Kbd>Esc</Kbd>
+            <span>Close search</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Kbd>Enter</Kbd>
+            <span>Next match</span>
+          </div>
+        </>
+      ) : focusedPanel === 'nav' ? (
+        // Nav panel shortcuts
+        <>
+          <div className="flex items-center gap-1">
+            <Kbd>⌘</Kbd>
+            <Kbd>F</Kbd>
+            <span>Search fields</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Kbd>↑</Kbd>
+            <Kbd>↓</Kbd>
+            <span>Navigate</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Kbd>Space</Kbd>
+            <span>Select / Toggle</span>
+          </div>
+          {selectedFieldCount > 0 && (
+            <div className="flex items-center gap-1">
+              <Kbd>⌘</Kbd>
+              <Kbd>⇧</Kbd>
+              <Kbd>A</Kbd>
+              <span>Clear all</span>
+            </div>
+          )}
+          {hasTableData && (
+            <div className="flex items-center gap-1">
+              <Kbd>Tab</Kbd>
+              <span>Go to table</span>
+            </div>
+          )}
+        </>
+      ) : focusedPanel === 'table' ? (
+        // Table shortcuts
+        <>
+          <div className="flex items-center gap-1">
+            <Kbd>⌘</Kbd>
+            <Kbd>F</Kbd>
+            <span>Search rows</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Kbd>↑</Kbd>
+            <Kbd>↓</Kbd>
+            <Kbd>←</Kbd>
+            <Kbd>→</Kbd>
+            <span>Navigate</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Kbd>Space</Kbd>
+            <span>Copy cell</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Kbd>Tab</Kbd>
+            <span>Go to fields</span>
+          </div>
+        </>
+      ) : (
+        // No focus - show hint
+        <>
+          <div className="flex items-center gap-1">
+            <Kbd>Tab</Kbd>
+            <span>Focus panel</span>
+          </div>
+        </>
+      )}
+
+      {/* Back to contexts */}
+      <div className="flex items-center gap-1 ml-auto">
+        <Kbd>⌘</Kbd>
+        <Kbd>[</Kbd>
+        <span>Back</span>
+      </div>
+    </div>
+  );
+}

--- a/cmd/gui/frontend/src/components/KeymapBar.tsx
+++ b/cmd/gui/frontend/src/components/KeymapBar.tsx
@@ -16,7 +16,7 @@ export function KeymapBar({
   hasTableData,
 }: KeymapBarProps) {
   return (
-    <div className="flex-shrink-0 px-4 py-2 border-t border-border bg-muted/30 flex gap-4 text-xs text-muted-foreground">
+    <div className="flex-shrink-0 px-4 py-2 border-t border-border flex gap-4 text-xs text-muted-foreground">
       {/* Common shortcuts */}
       <div className="flex items-center gap-1">
         <Kbd>⌘</Kbd>

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -87,11 +87,19 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
   }, [connectedContexts]);
 
   useEffect(() => {
-    // cmd+k to toggle CommandPalette
     const handleKeydown = (e: KeyboardEvent) => {
+      // cmd+k to toggle CommandPalette
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
         setShowCommandPalette((prev) => !prev);
+        return;
+      }
+
+      // cmd+shift+a to clear all field selections
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'a') {
+        e.preventDefault();
+        navigationPanelRef.current?.clearSelections();
+        return;
       }
     };
 

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -197,6 +197,20 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
         return;
       }
 
+      // cmd+shift+c to export to clipboard
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'c') {
+        e.preventDefault();
+        resultTableRef.current?.exportToClipboard();
+        return;
+      }
+
+      // cmd+shift+s to download as file
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        resultTableRef.current?.exportToFile();
+        return;
+      }
+
       // cmd+1~9 to apply favorite (works regardless of panel focus)
       if ((e.metaKey || e.ctrlKey) && e.key >= '1' && e.key <= '9') {
         const index = parseInt(e.key) - 1;

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -118,7 +118,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
         return;
       }
 
-      // cmd+f to focus search in current panel
+      // cmd+f to focus/toggle search in current panel
       if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
         e.preventDefault();
         if (focusedPanel === 'nav') {
@@ -300,7 +300,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
             className={`flex flex-col h-full transition-shadow ${
               focusedPanel === 'nav' ? 'ring-2 ring-primary/50 ring-inset' : ''
             }`}
-            onClick={() => setFocusedPanel('nav')}
+            onMouseDown={() => setFocusedPanel('nav')}
           >
             {/* Nav Header */}
             <NavHeader
@@ -362,7 +362,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
             className={`h-full relative transition-shadow ${
               focusedPanel === 'table' ? 'ring-2 ring-primary/50 ring-inset' : ''
             }`}
-            onClick={() => setFocusedPanel('table')}
+            onMouseDown={() => setFocusedPanel('table')}
           >
             {/* Floating Expand Button (only when collapsed) */}
             {isSidebarCollapsed && (
@@ -402,15 +402,13 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
         </ResizablePanel>
       </ResizablePanelGroup>
 
-      {/* Keymap Bar */}
-      {selectedGVK && (
-        <KeymapBar
-          focusedPanel={focusedPanel}
-          selectedFieldCount={selectedFields.length}
-          isSearchFocused={isNavSearchFocused() || isTableSearchFocused()}
-          hasTableData={selectedFields.length > 0}
-        />
-      )}
+      {/* Keymap Bar - always visible */}
+      <KeymapBar
+        focusedPanel={focusedPanel}
+        selectedFieldCount={selectedFields.length}
+        isSearchFocused={isNavSearchFocused() || isTableSearchFocused()}
+        hasTableData={selectedFields.length > 0}
+      />
 
       {/* CommandPalette Modal */}
       {showCommandPalette && (

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -15,6 +15,7 @@ import { ImperativePanelHandle } from "react-resizable-panels";
 import { useFavoriteViews } from "@/hooks/useFavoriteViews";
 import { useTheme } from "next-themes";
 import { toggleThemeWithAnimation } from "@/lib/theme-animation";
+import { isInputElementFocused } from "@/lib/dom-utils";
 
 interface MainViewProps {
   selectedContexts: string[];
@@ -261,11 +262,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
       // Arrow keys for navigation
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
         // Don't handle arrows if any input/textarea is focused
-        const activeEl = document.activeElement;
-        const isInputFocused = activeEl instanceof HTMLInputElement ||
-                               activeEl instanceof HTMLTextAreaElement ||
-                               activeEl?.getAttribute('contenteditable') === 'true';
-        if (isInputFocused) return;
+        if (isInputElementFocused()) return;
 
         if (focusedPanel === 'nav') {
           e.preventDefault();
@@ -292,11 +289,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
       // Space for toggle/select/copy
       if (e.key === ' ') {
         // Don't handle space if any input/textarea is focused
-        const activeEl = document.activeElement;
-        const isInputFocused = activeEl instanceof HTMLInputElement ||
-                               activeEl instanceof HTMLTextAreaElement ||
-                               activeEl?.getAttribute('contenteditable') === 'true';
-        if (isInputFocused) return;
+        if (isInputElementFocused()) return;
 
         if (focusedPanel === 'nav') {
           e.preventDefault();

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -149,8 +149,12 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
 
       // Arrow keys for navigation
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
-        // Don't handle arrows if search is focused
-        if (isNavSearchFocused() || isTableSearchFocused()) return;
+        // Don't handle arrows if any input/textarea is focused
+        const activeEl = document.activeElement;
+        const isInputFocused = activeEl instanceof HTMLInputElement ||
+                               activeEl instanceof HTMLTextAreaElement ||
+                               activeEl?.getAttribute('contenteditable') === 'true';
+        if (isInputFocused) return;
 
         if (focusedPanel === 'nav') {
           e.preventDefault();
@@ -176,8 +180,12 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
 
       // Space for toggle/select/copy
       if (e.key === ' ') {
-        // Don't handle space if search is focused
-        if (isNavSearchFocused() || isTableSearchFocused()) return;
+        // Don't handle space if any input/textarea is focused
+        const activeEl = document.activeElement;
+        const isInputFocused = activeEl instanceof HTMLInputElement ||
+                               activeEl instanceof HTMLTextAreaElement ||
+                               activeEl?.getAttribute('contenteditable') === 'true';
+        if (isInputFocused) return;
 
         if (focusedPanel === 'nav') {
           e.preventDefault();

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -3,7 +3,7 @@ import { CommandPalette } from "./CommandPalette";
 import { NavigationPanel, NavigationPanelHandle } from "./NavigationPanel";
 import { ResultTable, ResultTableHandle } from "./ResultTable";
 import { NavHeader } from "./NavHeader";
-import { QuickAccessBar } from "./QuickAccessBar";
+import { QuickAccessBar, QuickAccessBarHandle } from "./QuickAccessBar";
 import { KeymapBar, FocusedPanel } from "./KeymapBar";
 import { Button } from "./ui/button";
 import { Kbd } from "./ui/kbd";
@@ -37,6 +37,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
   const sidebarPanelRef = useRef<ImperativePanelHandle>(null);
   const navigationPanelRef = useRef<NavigationPanelHandle>(null);
   const resultTableRef = useRef<ResultTableHandle>(null);
+  const quickAccessBarRef = useRef<QuickAccessBarHandle>(null);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [focusedPanel, setFocusedPanel] = useState<FocusedPanel>(null);
   const { setTheme, resolvedTheme } = useTheme();
@@ -211,6 +212,13 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
         return;
       }
 
+      // cmd+s to save as favorite (when not already saved)
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        quickAccessBarRef.current?.openSavePopover();
+        return;
+      }
+
       // cmd+1~9 to apply favorite (works regardless of panel focus)
       if ((e.metaKey || e.ctrlKey) && e.key >= '1' && e.key <= '9') {
         const index = parseInt(e.key) - 1;
@@ -349,6 +357,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
 
             {/* Quick Access Bar for Favorites - always visible */}
             <QuickAccessBar
+              ref={quickAccessBarRef}
               favorites={allFavorites}
               activeFavoriteId={activeFavorite?.id ?? null}
               selectedGVK={selectedGVK}

--- a/cmd/gui/frontend/src/components/NavigationPanel.test.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.test.tsx
@@ -202,13 +202,15 @@ describe('NavigationPanel', () => {
       },
     ];
 
-    it('should toggle search bar with Cmd+F', async () => {
+    it('should toggle search bar via toggleSearch ref', async () => {
+      // Note: Cmd+F is handled by MainView, which calls toggleSearch via ref
       (App.GetNodeTree as any).mockResolvedValue(mockTreeData);
 
-      const user = userEvent.setup();
+      const ref = { current: null as any };
 
       render(
         <NavigationPanel
+          ref={ref}
           selectedGVK={mockGVK}
           connectedContexts={mockContexts}
           onFieldsSelected={mockOnFieldsSelected}
@@ -222,20 +224,26 @@ describe('NavigationPanel', () => {
       // Search bar should not be visible initially
       expect(screen.queryByPlaceholderText('Search ...')).not.toBeInTheDocument();
 
-      // Press Cmd+F
-      await user.keyboard('{Meta>}f{/Meta}');
+      // Toggle search via ref (simulates what MainView does on Cmd+F)
+      act(() => {
+        ref.current.toggleSearch();
+      });
 
       // Search bar should now be visible
-      expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
+      });
     });
 
     it('should close search with Escape', async () => {
       (App.GetNodeTree as any).mockResolvedValue(mockTreeData);
 
       const user = userEvent.setup();
+      const ref = { current: null as any };
 
       render(
         <NavigationPanel
+          ref={ref}
           selectedGVK={mockGVK}
           connectedContexts={mockContexts}
           onFieldsSelected={mockOnFieldsSelected}
@@ -246,9 +254,13 @@ describe('NavigationPanel', () => {
         expect(screen.getByText('metadata')).toBeInTheDocument();
       });
 
-      // Open search
-      await user.keyboard('{Meta>}f{/Meta}');
-      expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
+      // Open search via ref
+      act(() => {
+        ref.current.toggleSearch();
+      });
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
+      });
 
       // Press Escape
       await user.keyboard('{Escape}');
@@ -750,9 +762,11 @@ describe('NavigationPanel', () => {
       (App.GetNodeTree as any).mockResolvedValue(mockTreeData);
 
       const user = userEvent.setup();
+      const ref = { current: null as any };
 
       render(
         <NavigationPanel
+          ref={ref}
           selectedGVK={mockGVK}
           connectedContexts={mockContexts}
           onFieldsSelected={mockOnFieldsSelected}
@@ -774,8 +788,13 @@ describe('NavigationPanel', () => {
       // spec should be collapsed
       expect(screen.queryByText('nodeName')).not.toBeInTheDocument();
 
-      // Open search and search for "nodeName"
-      await user.keyboard('{Meta>}f{/Meta}');
+      // Open search via ref
+      act(() => {
+        ref.current.toggleSearch();
+      });
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
+      });
       const searchInput = screen.getByPlaceholderText('Search ...');
       await user.type(searchInput, 'nodeName');
 
@@ -802,9 +821,11 @@ describe('NavigationPanel', () => {
       (App.GetNodeTree as any).mockResolvedValue(mockTreeData);
 
       const user = userEvent.setup();
+      const ref = { current: null as any };
 
       render(
         <NavigationPanel
+          ref={ref}
           selectedGVK={mockGVK}
           connectedContexts={mockContexts}
           onFieldsSelected={mockOnFieldsSelected}
@@ -815,8 +836,13 @@ describe('NavigationPanel', () => {
         expect(screen.getByText('metadata')).toBeInTheDocument();
       });
 
-      // Open search and search for "namespace"
-      await user.keyboard('{Meta>}f{/Meta}');
+      // Open search via ref
+      act(() => {
+        ref.current.toggleSearch();
+      });
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
+      });
       const searchInput = screen.getByPlaceholderText('Search ...');
       await user.type(searchInput, 'namespace');
 

--- a/cmd/gui/frontend/src/components/NavigationPanel.test.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.test.tsx
@@ -220,13 +220,13 @@ describe('NavigationPanel', () => {
       });
 
       // Search bar should not be visible initially
-      expect(screen.queryByPlaceholderText('Search...')).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Search ...')).not.toBeInTheDocument();
 
       // Press Cmd+F
       await user.keyboard('{Meta>}f{/Meta}');
 
       // Search bar should now be visible
-      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
     });
 
     it('should close search with Escape', async () => {
@@ -248,14 +248,14 @@ describe('NavigationPanel', () => {
 
       // Open search
       await user.keyboard('{Meta>}f{/Meta}');
-      expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
 
       // Press Escape
       await user.keyboard('{Escape}');
 
       // Search bar should be closed
       await waitFor(() => {
-        expect(screen.queryByPlaceholderText('Search...')).not.toBeInTheDocument();
+        expect(screen.queryByPlaceholderText('Search ...')).not.toBeInTheDocument();
       });
     });
   });
@@ -776,7 +776,7 @@ describe('NavigationPanel', () => {
 
       // Open search and search for "nodeName"
       await user.keyboard('{Meta>}f{/Meta}');
-      const searchInput = screen.getByPlaceholderText('Search...');
+      const searchInput = screen.getByPlaceholderText('Search ...');
       await user.type(searchInput, 'nodeName');
 
       // Wait for search results - spec should auto-expand to show nodeName
@@ -817,7 +817,7 @@ describe('NavigationPanel', () => {
 
       // Open search and search for "namespace"
       await user.keyboard('{Meta>}f{/Meta}');
-      const searchInput = screen.getByPlaceholderText('Search...');
+      const searchInput = screen.getByPlaceholderText('Search ...');
       await user.type(searchInput, 'namespace');
 
       // metadata should auto-expand due to search
@@ -1050,7 +1050,7 @@ describe('NavigationPanel', () => {
       });
 
       // Search should not be visible initially
-      expect(screen.queryByPlaceholderText('Search...')).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Search ...')).not.toBeInTheDocument();
 
       // Toggle search via ref
       act(() => {
@@ -1058,7 +1058,7 @@ describe('NavigationPanel', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
       });
 
       // Toggle again to close
@@ -1067,7 +1067,7 @@ describe('NavigationPanel', () => {
       });
 
       await waitFor(() => {
-        expect(screen.queryByPlaceholderText('Search...')).not.toBeInTheDocument();
+        expect(screen.queryByPlaceholderText('Search ...')).not.toBeInTheDocument();
       });
     });
   });

--- a/cmd/gui/frontend/src/components/NavigationPanel.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.tsx
@@ -22,6 +22,11 @@ export interface NavigationPanelHandle {
   getSelectedPaths: () => Set<string>;
   setSelectedPaths: (paths: Set<string>) => void;
   toggleSearch: () => void;
+  // Keyboard navigation
+  navigateUp: () => void;
+  navigateDown: () => void;
+  toggleFocused: () => void;
+  isSearchFocused: () => boolean;
 }
 
 interface TreeNodeItemProps {
@@ -192,6 +197,11 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
     clearAllSelections,
     setSelectionsFromPaths,
 
+    // Keyboard navigation
+    focusedPathKey,
+    navigateFocus,
+    toggleFocused,
+
     // Filtered view
     filteredNodeTree,
   } = useTree({
@@ -208,7 +218,11 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
     getSelectedPaths: () => new Set(selectedPaths),
     setSelectedPaths: setSelectionsFromPaths,
     toggleSearch,
-  }), [clearAllSelections, selectedPaths, setSelectionsFromPaths, toggleSearch]);
+    navigateUp: () => navigateFocus('up'),
+    navigateDown: () => navigateFocus('down'),
+    toggleFocused,
+    isSearchFocused: () => searchVisible,
+  }), [clearAllSelections, selectedPaths, setSelectionsFromPaths, toggleSearch, navigateFocus, toggleFocused, searchVisible]);
 
   return (
     <div className="flex flex-col h-full relative">
@@ -249,7 +263,12 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
                 onToggleExpand={toggleExpand}
                 onToggleSelect={toggleSelect}
                 searchResultsMap={searchResultsMap}
-                focusedPath={debouncedQuery && matchedPaths.length > 0 ? matchedPaths[currentMatchIndex] : undefined}
+                focusedPath={
+                  // Priority: search match focus > keyboard focus
+                  debouncedQuery && matchedPaths.length > 0
+                    ? matchedPaths[currentMatchIndex]
+                    : focusedPathKey ?? undefined
+                }
               />
             ))}
           </div>

--- a/cmd/gui/frontend/src/components/NavigationPanel.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.tsx
@@ -3,7 +3,7 @@ import { Button } from './ui/button';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Checkbox } from './ui/checkbox';
 import { Spinner } from './ui/spinner';
-import { FieldSearchBar } from './FieldSearchBar';
+import { FieldSearchBar, FieldSearchBarHandle } from './FieldSearchBar';
 import { main } from '../../wailsjs/go/models';
 import { useTree, TreeNode, PATH_DELIMITER } from '@/hooks/useTree';
 import { HighlightedText } from './HighlightedText';
@@ -212,6 +212,8 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
     watch: true,  // Enable real-time tree updates
   });
 
+  const fieldSearchBarRef = useRef<FieldSearchBarHandle>(null);
+
   useImperativeHandle(ref, () => ({
     clearSelections: clearAllSelections,
     getSelectedCount: () => selectedPaths.size,
@@ -221,8 +223,8 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
     navigateUp: () => navigateFocus('up'),
     navigateDown: () => navigateFocus('down'),
     toggleFocused,
-    isSearchFocused: () => searchVisible,
-  }), [clearAllSelections, selectedPaths, setSelectionsFromPaths, toggleSearch, navigateFocus, toggleFocused, searchVisible]);
+    isSearchFocused: () => fieldSearchBarRef.current?.isInputFocused() ?? false,
+  }), [clearAllSelections, selectedPaths, setSelectionsFromPaths, toggleSearch, navigateFocus, toggleFocused]);
 
   return (
     <div className="flex flex-col h-full relative">
@@ -230,6 +232,7 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
       {/* TODO: Add slide-down/slide-up animation when showing/hiding */}
       {searchVisible && (
         <FieldSearchBar
+          ref={fieldSearchBarRef}
           query={query}
           onQueryChange={setQuery}
           currentMatchIndex={currentMatchIndex}

--- a/cmd/gui/frontend/src/components/NavigationPanel.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.tsx
@@ -37,6 +37,7 @@ interface TreeNodeItemProps {
   onToggleSelect: (path: string[]) => void;
   searchResultsMap: Map<string, readonly [number, number][] | null>;
   focusedPath?: string;
+  onFocus?: (pathKey: string) => void;
 }
 
 // Memoized TreeNode component to prevent unnecessary re-renders
@@ -48,6 +49,7 @@ const TreeNodeItem = memo(({
   onToggleSelect,
   searchResultsMap,
   focusedPath,
+  onFocus,
 }: TreeNodeItemProps) => {
   const hasChildren = node.children && node.children.length > 0;
   const isArrayOrMap = node.type && (node.type.startsWith('[]') || node.type.startsWith('map['));
@@ -78,6 +80,10 @@ const TreeNodeItem = memo(({
     onToggleSelect(node.fullPath);
   }, [node.fullPath, onToggleSelect]);
 
+  const handleMouseEnter = useCallback(() => {
+    onFocus?.(pathKey);
+  }, [onFocus, pathKey]);
+
   return (
     <div className="relative">
       {/* Indent guide lines - with higher z-index to stay visible on hover */}
@@ -96,9 +102,10 @@ const TreeNodeItem = memo(({
       <div
         ref={nodeRef}
         className={`flex items-center py-0.5 pr-2 rounded-sm relative ${
-          isFocused ? 'bg-focus-active' : 'hover:bg-focus'
+          isFocused ? 'bg-focus' : ''
         }`}
         style={{ paddingLeft: `${node.level * 12 + 2}px` }}
+        onMouseEnter={handleMouseEnter}
       >
 
         {/* Expand/Collapse button OR Checkbox (mutually exclusive) */}
@@ -155,6 +162,7 @@ const TreeNodeItem = memo(({
               onToggleSelect={onToggleSelect}
               searchResultsMap={searchResultsMap}
               focusedPath={focusedPath}
+              onFocus={onFocus}
             />
           ))}
         </div>
@@ -199,6 +207,7 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
 
     // Keyboard navigation
     focusedPathKey,
+    setFocusedPath,
     navigateFocus,
     toggleFocused,
 
@@ -272,6 +281,8 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
                     ? matchedPaths[currentMatchIndex]
                     : focusedPathKey ?? undefined
                 }
+                // Only enable mouse hover focus when not searching
+                onFocus={!debouncedQuery ? setFocusedPath : undefined}
               />
             ))}
           </div>

--- a/cmd/gui/frontend/src/components/QuickAccessBar.tsx
+++ b/cmd/gui/frontend/src/components/QuickAccessBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { Star, ChevronRight, ChevronDown, Pencil, Trash2, Check, X } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+import { Kbd } from "./ui/kbd";
 import {
   Collapsible,
   CollapsibleContent,
@@ -318,9 +319,10 @@ export function QuickAccessBar({
 
         <CollapsibleContent>
           <div className="border-t border-border">
-            {favorites.map((fav) => {
+            {favorites.map((fav, index) => {
               const isActive = fav.id === activeFavoriteId;
               const isEditing = fav.id === editingId;
+              const shortcutNumber = index < 9 ? index + 1 : null;
 
               if (isEditing) {
                 return (
@@ -382,12 +384,18 @@ export function QuickAccessBar({
                     }
                   }}
                 >
-                  <Star
-                    className={cn(
-                      "h-3 w-3 shrink-0",
-                      isActive ? "text-accent fill-accent" : "text-accent/60"
-                    )}
-                  />
+                  {shortcutNumber ? (
+                    <Kbd className="text-[10px] w-4 h-4 flex items-center justify-center shrink-0">
+                      {shortcutNumber}
+                    </Kbd>
+                  ) : (
+                    <Star
+                      className={cn(
+                        "h-3 w-3 shrink-0",
+                        isActive ? "text-accent fill-accent" : "text-accent/60"
+                      )}
+                    />
+                  )}
 
                   {/* Name with minimum width guarantee */}
                   <div className="flex items-center gap-2 flex-1 min-w-0 overflow-hidden">

--- a/cmd/gui/frontend/src/components/QuickAccessBar.tsx
+++ b/cmd/gui/frontend/src/components/QuickAccessBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from "react";
 import { Star, ChevronRight, ChevronDown, Pencil, Trash2, Check, X } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -39,7 +39,11 @@ interface QuickAccessBarProps {
   onSaveFavorite: (name: string) => Promise<void>;
 }
 
-export function QuickAccessBar({
+export interface QuickAccessBarHandle {
+  openSavePopover: () => void;
+}
+
+export const QuickAccessBar = forwardRef<QuickAccessBarHandle, QuickAccessBarProps>(({
   favorites,
   activeFavoriteId,
   selectedGVK,
@@ -51,7 +55,7 @@ export function QuickAccessBar({
   onRename,
   onDelete,
   onSaveFavorite,
-}: QuickAccessBarProps) {
+}, ref) => {
   const [isOpen, setIsOpen] = useState(true);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
@@ -65,6 +69,16 @@ export function QuickAccessBar({
   const [isSaving, setIsSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const saveInputRef = useRef<HTMLInputElement>(null);
+
+  // Expose methods via ref
+  const canSave = selectedGVK && fieldCount > 0 && !isFavoriteSaved;
+  useImperativeHandle(ref, () => ({
+    openSavePopover: () => {
+      if (canSave) {
+        setSavePopoverOpen(true);
+      }
+    },
+  }), [canSave]);
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -504,4 +518,6 @@ export function QuickAccessBar({
       </AlertDialog>
     </>
   );
-}
+});
+
+QuickAccessBar.displayName = 'QuickAccessBar';

--- a/cmd/gui/frontend/src/components/ResultTable.tsx
+++ b/cmd/gui/frontend/src/components/ResultTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react';
+import { useState, useMemo, useRef, forwardRef, useImperativeHandle, useCallback, useEffect } from 'react';
 import {
   useReactTable,
   getCoreRowModel,
@@ -12,7 +12,7 @@ import { rankItem } from '@tanstack/match-sorter-utils';
 import { cn } from '../lib/utils';
 import { Spinner } from './ui/spinner';
 import { CellContent } from './CellContent';
-import { ResultTableToolbar } from './ResultTableToolbar';
+import { ResultTableToolbar, ResultTableToolbarHandle } from './ResultTableToolbar';
 import { useCellHighlight } from '../hooks/useCellHighlight';
 import { useResourceData } from '../hooks/useResourceData';
 import { useFlashingCells } from '../hooks/useFlashingCells';
@@ -22,6 +22,16 @@ interface ResultTableProps {
   selectedFields: string[][];  // From NavigationPanel
   selectedGVK: main.MultiClusterGVK;
   connectedContexts: string[];
+}
+
+export interface ResultTableHandle {
+  focusSearch: () => void;
+  isSearchFocused: () => boolean;
+  navigateUp: () => void;
+  navigateDown: () => void;
+  navigateLeft: () => void;
+  navigateRight: () => void;
+  copyFocusedCell: () => void;
 }
 
 // Helper function to get nested value from object using path
@@ -41,11 +51,11 @@ const fuzzyFilter = (row: any, columnId: string, value: any, addMeta: any) => {
   return itemRank.passed;
 };
 
-export function ResultTable({
+export const ResultTable = forwardRef<ResultTableHandle, ResultTableProps>(({
   selectedFields,
   selectedGVK,
   connectedContexts,
-}: ResultTableProps) {
+}, ref) => {
   // Use extracted hook for data fetching (watch enabled for real-time updates)
   const { data, loading, getRowId, changedCells } = useResourceData(
     selectedGVK,
@@ -58,9 +68,20 @@ export function ResultTable({
 
   const [globalFilter, setGlobalFilter] = useState('');
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<ResultTableToolbarHandle>(null);
+
+  // Keyboard navigation state
+  const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
+  const [focusedColIndex, setFocusedColIndex] = useState<number | null>(null);
 
   // Get highlight function based on current search query
   const getHighlightIndices = useCellHighlight(globalFilter);
+
+  // Reset focus when data changes
+  useEffect(() => {
+    setFocusedRowIndex(null);
+    setFocusedColIndex(null);
+  }, [selectedGVK]);
 
   // Calculate column width based on field name and data
   // Returns { size: initial display width, maxSize: max possible width }
@@ -183,6 +204,77 @@ export function ResultTable({
   // Get filtered rows for virtualization
   const { rows } = table.getRowModel();
 
+  // Navigation callbacks (must be defined after rows and columns)
+  const navigateUp = useCallback(() => {
+    setFocusedRowIndex((prev) => {
+      if (prev === null) return rows.length > 0 ? 0 : null;
+      return Math.max(0, prev - 1);
+    });
+    if (focusedColIndex === null && columns.length > 0) {
+      setFocusedColIndex(0);
+    }
+  }, [rows.length, focusedColIndex, columns.length]);
+
+  const navigateDown = useCallback(() => {
+    setFocusedRowIndex((prev) => {
+      if (prev === null) return rows.length > 0 ? 0 : null;
+      return Math.min(rows.length - 1, prev + 1);
+    });
+    if (focusedColIndex === null && columns.length > 0) {
+      setFocusedColIndex(0);
+    }
+  }, [rows.length, focusedColIndex, columns.length]);
+
+  const navigateLeft = useCallback(() => {
+    setFocusedColIndex((prev) => {
+      if (prev === null) return columns.length > 0 ? 0 : null;
+      return Math.max(0, prev - 1);
+    });
+    if (focusedRowIndex === null && rows.length > 0) {
+      setFocusedRowIndex(0);
+    }
+  }, [columns.length, focusedRowIndex, rows.length]);
+
+  const navigateRight = useCallback(() => {
+    setFocusedColIndex((prev) => {
+      if (prev === null) return columns.length > 0 ? 0 : null;
+      return Math.min(columns.length - 1, prev + 1);
+    });
+    if (focusedRowIndex === null && rows.length > 0) {
+      setFocusedRowIndex(0);
+    }
+  }, [columns.length, focusedRowIndex, rows.length]);
+
+  const copyFocusedCell = useCallback(() => {
+    if (focusedRowIndex === null || focusedColIndex === null) return;
+    const row = rows[focusedRowIndex];
+    if (!row) return;
+    const cell = row.getVisibleCells()[focusedColIndex];
+    if (!cell) return;
+
+    const value = cell.getValue();
+    const text = typeof value === 'object' && value !== null
+      ? JSON.stringify(value)
+      : String(value ?? '');
+
+    navigator.clipboard.writeText(text).catch(console.error);
+  }, [focusedRowIndex, focusedColIndex, rows]);
+
+  // Expose handle methods
+  useImperativeHandle(ref, () => ({
+    focusSearch: () => {
+      toolbarRef.current?.focusSearch();
+    },
+    isSearchFocused: () => {
+      return toolbarRef.current?.isSearchFocused() ?? false;
+    },
+    navigateUp,
+    navigateDown,
+    navigateLeft,
+    navigateRight,
+    copyFocusedCell,
+  }), [navigateUp, navigateDown, navigateLeft, navigateRight, copyFocusedCell]);
+
   // Get total width from table state (updates on resize)
   const totalColumnsWidth = table.getTotalSize();
 
@@ -193,6 +285,13 @@ export function ResultTable({
     estimateSize: () => 28,  // Estimated row height in pixels (reduced from 35)
     overscan: 10,  // Render 10 extra rows above/below viewport
   });
+
+  // Auto-scroll to keep focused row visible
+  useEffect(() => {
+    if (focusedRowIndex !== null) {
+      rowVirtualizer.scrollToIndex(focusedRowIndex, { align: 'auto' });
+    }
+  }, [focusedRowIndex, rowVirtualizer]);
 
   // Prepare export data (headers and rows for CSV)
   const exportData = useMemo(() => {
@@ -221,6 +320,7 @@ export function ResultTable({
     <div className="flex flex-col h-full">
       {/* Toolbar with Search and Export */}
       <ResultTableToolbar
+        ref={toolbarRef}
         globalFilter={globalFilter}
         onGlobalFilterChange={setGlobalFilter}
         filteredRowCount={rows.length}
@@ -293,31 +393,39 @@ export function ResultTable({
             >
               {rowVirtualizer.getVirtualItems().map((virtualRow) => {
                 const row = rows[virtualRow.index];
+                const isRowFocused = focusedRowIndex === virtualRow.index;
                 return (
                   <div
                     key={row.id}
-                    className="flex border-b border-border hover:bg-focus transition-colors absolute top-0 left-0"
+                    className={cn(
+                      "flex border-b border-border hover:bg-focus transition-colors absolute top-0 left-0",
+                      isRowFocused && "bg-focus"
+                    )}
                     style={{
                       height: `${virtualRow.size}px`,
                       transform: `translateY(${virtualRow.start}px)`,
                       width: `max(${totalColumnsWidth}px, 100%)`,
                     }}
                   >
-                    {row.getVisibleCells().map((cell) => (
-                      <div
-                        key={cell.id}
-                        className={cn(
-                          "px-4 py-1 text-sm flex-shrink-0",
-                          isFlashing(row.id, cell.column.id) && "animate-cell-flash"
-                        )}
-                        style={{
-                          width: `${cell.column.getSize()}px`,
-                          minWidth: `${cell.column.columnDef.minSize || 80}px`,
-                        }}
-                      >
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </div>
-                    ))}
+                    {row.getVisibleCells().map((cell, cellIndex) => {
+                      const isCellFocused = isRowFocused && focusedColIndex === cellIndex;
+                      return (
+                        <div
+                          key={cell.id}
+                          className={cn(
+                            "px-4 py-1 text-sm flex-shrink-0",
+                            isFlashing(row.id, cell.column.id) && "animate-cell-flash",
+                            isCellFocused && "ring-2 ring-primary ring-inset"
+                          )}
+                          style={{
+                            width: `${cell.column.getSize()}px`,
+                            minWidth: `${cell.column.columnDef.minSize || 80}px`,
+                          }}
+                        >
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </div>
+                      );
+                    })}
                   </div>
                 );
               })}
@@ -327,4 +435,6 @@ export function ResultTable({
       </div>
     </div>
   );
-}
+});
+
+ResultTable.displayName = 'ResultTable';

--- a/cmd/gui/frontend/src/components/ResultTable.tsx
+++ b/cmd/gui/frontend/src/components/ResultTable.tsx
@@ -69,7 +69,7 @@ export const ResultTable = forwardRef<ResultTableHandle, ResultTableProps>(({
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const toolbarRef = useRef<ResultTableToolbarHandle>(null);
 
-  // Keyboard navigation state
+  // Unified focus state (keyboard navigation + mouse hover)
   const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
   const [focusedColIndex, setFocusedColIndex] = useState<number | null>(null);
   // Track copied cell for "Copied" feedback
@@ -436,6 +436,11 @@ export const ResultTable = forwardRef<ResultTableHandle, ResultTableProps>(({
                           style={{
                             width: `${cell.column.getSize()}px`,
                             minWidth: `${cell.column.columnDef.minSize || 80}px`,
+                          }}
+                          onMouseEnter={() => {
+                            // Mouse hover moves focus to this cell
+                            setFocusedRowIndex(virtualRow.index);
+                            setFocusedColIndex(cellIndex);
                           }}
                         >
                           <CellContent

--- a/cmd/gui/frontend/src/components/ResultTable.tsx
+++ b/cmd/gui/frontend/src/components/ResultTable.tsx
@@ -31,6 +31,8 @@ export interface ResultTableHandle {
   navigateLeft: () => void;
   navigateRight: () => void;
   copyFocusedCell: () => void;
+  exportToClipboard: () => void;
+  exportToFile: () => void;
 }
 
 // Helper function to get nested value from object using path
@@ -280,6 +282,12 @@ export const ResultTable = forwardRef<ResultTableHandle, ResultTableProps>(({
     navigateLeft,
     navigateRight,
     copyFocusedCell,
+    exportToClipboard: () => {
+      toolbarRef.current?.exportToClipboard();
+    },
+    exportToFile: () => {
+      toolbarRef.current?.exportToFile();
+    },
   }), [navigateUp, navigateDown, navigateLeft, navigateRight, copyFocusedCell]);
 
   // Get total width from table state (updates on resize)

--- a/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
@@ -8,6 +8,7 @@ import {
 } from './ui/dropdown-menu';
 import { Download, Clipboard, FileDown, AlertCircle } from 'lucide-react';
 import { useState, forwardRef, useRef, useImperativeHandle } from 'react';
+import { Kbd } from './ui/kbd';
 import { convertToCSV, copyToClipboard, downloadCSV } from '@/lib/csv-export';
 import { SaveFile } from '../../wailsjs/go/main/App';
 
@@ -25,6 +26,8 @@ interface ResultTableToolbarProps {
 export interface ResultTableToolbarHandle {
   focusSearch: () => void;
   isSearchFocused: () => boolean;
+  exportToClipboard: () => void;
+  exportToFile: () => void;
 }
 
 export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTableToolbarProps>(({
@@ -39,15 +42,6 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
   const [exporting, setExporting] = useState(false);
   const [exportStatus, setExportStatus] = useState<'idle' | 'copied' | 'downloaded' | 'error'>('idle');
   const searchInputRef = useRef<HTMLInputElement>(null);
-
-  useImperativeHandle(ref, () => ({
-    focusSearch: () => {
-      searchInputRef.current?.focus();
-    },
-    isSearchFocused: () => {
-      return document.activeElement === searchInputRef.current;
-    },
-  }), []);
 
   const handleExportToClipboard = async () => {
     try {
@@ -96,6 +90,18 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
       setExporting(false);
     }
   };
+
+  // Expose methods via ref
+  useImperativeHandle(ref, () => ({
+    focusSearch: () => {
+      searchInputRef.current?.focus();
+    },
+    isSearchFocused: () => {
+      return document.activeElement === searchInputRef.current;
+    },
+    exportToClipboard: handleExportToClipboard,
+    exportToFile: handleExportToFile,
+  }), []);
 
   return (
     <div className="p-4 border-b border-border">
@@ -146,11 +152,17 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
           <DropdownMenuContent align="end">
             <DropdownMenuItem onClick={handleExportToClipboard}>
               <Clipboard className="mr-2 h-4 w-4" />
-              <span>Copy to Clipboard</span>
+              <span className="flex-1">Copy to Clipboard</span>
+              <span className="ml-4 flex items-center gap-0.5">
+                <Kbd>⌘</Kbd><Kbd>⇧</Kbd><Kbd>C</Kbd>
+              </span>
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleExportToFile}>
               <FileDown className="mr-2 h-4 w-4" />
-              <span>Download as File</span>
+              <span className="flex-1">Download as File</span>
+              <span className="ml-4 flex items-center gap-0.5">
+                <Kbd>⌘</Kbd><Kbd>⇧</Kbd><Kbd>S</Kbd>
+              </span>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
@@ -88,7 +88,7 @@ export function ResultTableToolbar({
         {/* Left: Search input */}
         <div className="flex-1 max-w-sm">
           <Input
-            placeholder="Search all fields..."
+            placeholder="Search ..."
             value={globalFilter}
             onChange={(e) => onGlobalFilterChange(e.target.value)}
           />

--- a/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 import { Download, Clipboard, FileDown, AlertCircle } from 'lucide-react';
-import { useState } from 'react';
+import { useState, forwardRef, useRef, useImperativeHandle } from 'react';
 import { convertToCSV, copyToClipboard, downloadCSV } from '@/lib/csv-export';
 import { SaveFile } from '../../wailsjs/go/main/App';
 
@@ -22,7 +22,12 @@ interface ResultTableToolbarProps {
   resourceKind?: string; // For filename generation
 }
 
-export function ResultTableToolbar({
+export interface ResultTableToolbarHandle {
+  focusSearch: () => void;
+  isSearchFocused: () => boolean;
+}
+
+export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTableToolbarProps>(({
   globalFilter,
   onGlobalFilterChange,
   filteredRowCount,
@@ -30,9 +35,19 @@ export function ResultTableToolbar({
   headers,
   rows,
   resourceKind = 'resources',
-}: ResultTableToolbarProps) {
+}, ref) => {
   const [exporting, setExporting] = useState(false);
   const [exportStatus, setExportStatus] = useState<'idle' | 'copied' | 'downloaded' | 'error'>('idle');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    focusSearch: () => {
+      searchInputRef.current?.focus();
+    },
+    isSearchFocused: () => {
+      return document.activeElement === searchInputRef.current;
+    },
+  }), []);
 
   const handleExportToClipboard = async () => {
     try {
@@ -88,6 +103,7 @@ export function ResultTableToolbar({
         {/* Left: Search input */}
         <div className="flex-1 max-w-sm">
           <Input
+            ref={searchInputRef}
             placeholder="Search ..."
             value={globalFilter}
             onChange={(e) => onGlobalFilterChange(e.target.value)}
@@ -141,4 +157,6 @@ export function ResultTableToolbar({
       </div>
     </div>
   );
-}
+});
+
+ResultTableToolbar.displayName = 'ResultTableToolbar';

--- a/cmd/gui/frontend/src/hooks/useTree.ts
+++ b/cmd/gui/frontend/src/hooks/useTree.ts
@@ -33,6 +33,9 @@ interface TreeState {
 
   // Selection
   selectedPaths: Set<string>;
+
+  // Keyboard navigation
+  focusedPathKey: string | null;
 }
 
 // Actions - includes future real-time update actions
@@ -65,7 +68,10 @@ type TreeAction =
   // Real-time tree structure updates (batched)
   // - additions: new array indices or map keys discovered from watch events
   // - removals: paths that no longer exist in any watched resource
-  | { type: 'MERGE_TREE_NODES'; additions: { parentPathKey: string; node: TreeNode }[]; removals: string[] };
+  | { type: 'MERGE_TREE_NODES'; additions: { parentPathKey: string; node: TreeNode }[]; removals: string[] }
+
+  // Keyboard navigation
+  | { type: 'SET_FOCUSED_PATH'; pathKey: string | null };
 
 // Initial state
 const initialState: TreeState = {
@@ -76,6 +82,7 @@ const initialState: TreeState = {
   debouncedQuery: '',
   manualExpandedPaths: new Set(),
   selectedPaths: new Set(),
+  focusedPathKey: null,
 };
 
 // Reducer
@@ -299,6 +306,12 @@ function treeReducer(state: TreeState, action: TreeAction): TreeState {
       return state;
     }
 
+    case 'SET_FOCUSED_PATH':
+      return {
+        ...state,
+        focusedPathKey: action.pathKey,
+      };
+
     default:
       return state;
   }
@@ -367,6 +380,7 @@ export function useTree({
     debouncedQuery,
     manualExpandedPaths,
     selectedPaths,
+    focusedPathKey,
   } = state;
 
   // Use ref for stable callback access
@@ -700,6 +714,63 @@ export function useTree({
     dispatch({ type: 'SET_SELECTIONS', paths, parentPathKeys });
   }, []);
 
+  // Get visible nodes in display order (considering expansion)
+  const getVisibleNodes = useCallback((): string[] => {
+    const visible: string[] = [];
+    const traverse = (nodes: TreeNode[]) => {
+      for (const node of nodes) {
+        const pathKey = node.fullPath.join(PATH_DELIMITER);
+        visible.push(pathKey);
+        // Only traverse children if this node is expanded
+        if (node.children && node.children.length > 0 && expandedPaths.has(pathKey)) {
+          traverse(node.children);
+        }
+      }
+    };
+    traverse(filteredNodeTree);
+    return visible;
+  }, [filteredNodeTree, expandedPaths]);
+
+  // Keyboard navigation
+  const setFocusedPath = useCallback((pathKey: string | null) => {
+    dispatch({ type: 'SET_FOCUSED_PATH', pathKey });
+  }, []);
+
+  const navigateFocus = useCallback((direction: 'up' | 'down') => {
+    const visibleNodes = getVisibleNodes();
+    if (visibleNodes.length === 0) return;
+
+    const currentIndex = focusedPathKey ? visibleNodes.indexOf(focusedPathKey) : -1;
+    let newIndex: number;
+
+    if (direction === 'down') {
+      newIndex = currentIndex < 0 ? 0 : Math.min(currentIndex + 1, visibleNodes.length - 1);
+    } else {
+      newIndex = currentIndex <= 0 ? 0 : currentIndex - 1;
+    }
+
+    dispatch({ type: 'SET_FOCUSED_PATH', pathKey: visibleNodes[newIndex] });
+  }, [focusedPathKey, getVisibleNodes]);
+
+  const toggleFocused = useCallback(() => {
+    if (!focusedPathKey) return;
+
+    const node = flatNodesMap.get(focusedPathKey);
+    if (!node) return;
+
+    const hasChildren = node.children && node.children.length > 0;
+    const isArrayOrMap = node.type && (node.type.startsWith('[]') || node.type.startsWith('map['));
+    const isLeaf = !hasChildren && !isArrayOrMap;
+
+    if (isLeaf) {
+      // Toggle selection for leaf nodes
+      toggleSelect(node.fullPath);
+    } else {
+      // Toggle expansion for parent nodes
+      toggleExpand(node.fullPath);
+    }
+  }, [focusedPathKey, flatNodesMap, toggleSelect, toggleExpand]);
+
   const toggleSearch = useCallback(() => {
     if (searchVisibleRef.current) {
       dispatch({ type: 'CLOSE_SEARCH' });
@@ -781,6 +852,12 @@ export function useTree({
     toggleSelect,
     clearAllSelections,
     setSelectionsFromPaths,
+
+    // Keyboard navigation
+    focusedPathKey,
+    setFocusedPath,
+    navigateFocus,
+    toggleFocused,
 
     // Filtered view
     filteredNodeTree,

--- a/cmd/gui/frontend/src/hooks/useTree.ts
+++ b/cmd/gui/frontend/src/hooks/useTree.ts
@@ -789,18 +789,12 @@ export function useTree({
     dispatch({ type: 'NAVIGATE_MATCH', direction, totalMatches: matchedPaths.length });
   }, [matchedPaths.length]);
 
-  // Keyboard shortcuts
+  // Keyboard shortcuts (when search is visible)
+  // Note: Cmd+F is handled by MainView.tsx for panel-aware focus
   useEffect(() => {
+    if (!searchVisible) return;
+
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd+F / Ctrl+F: Toggle search
-      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
-        e.preventDefault();
-        toggleSearch();
-        return;
-      }
-
-      if (!searchVisible) return;
-
       // Esc: Close search
       if (e.key === 'Escape') {
         closeSearch();
@@ -817,7 +811,7 @@ export function useTree({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [searchVisible, query, navigateMatches, toggleSearch, closeSearch]);
+  }, [searchVisible, query, navigateMatches, closeSearch]);
 
   // Ensure currentMatchIndex is always valid (handles race between matchedPaths shrinking and RESET_MATCH_INDEX effect)
   const boundedMatchIndex = matchedPaths.length > 0

--- a/cmd/gui/frontend/src/lib/dom-utils.test.ts
+++ b/cmd/gui/frontend/src/lib/dom-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isInputElementFocused } from './dom-utils';
+
+describe('isInputElementFocused', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('should return true when input element is focused', () => {
+    const input = document.createElement('input');
+    container.appendChild(input);
+    input.focus();
+
+    expect(isInputElementFocused()).toBe(true);
+  });
+
+  it('should return true when textarea element is focused', () => {
+    const textarea = document.createElement('textarea');
+    container.appendChild(textarea);
+    textarea.focus();
+
+    expect(isInputElementFocused()).toBe(true);
+  });
+
+  it('should return true when contenteditable element is focused', () => {
+    const div = document.createElement('div');
+    div.setAttribute('contenteditable', 'true');
+    container.appendChild(div);
+    div.focus();
+
+    expect(isInputElementFocused()).toBe(true);
+  });
+
+  it('should return false when regular div is focused', () => {
+    const div = document.createElement('div');
+    div.tabIndex = 0; // Make it focusable
+    container.appendChild(div);
+    div.focus();
+
+    expect(isInputElementFocused()).toBe(false);
+  });
+
+  it('should return false when button is focused', () => {
+    const button = document.createElement('button');
+    container.appendChild(button);
+    button.focus();
+
+    expect(isInputElementFocused()).toBe(false);
+  });
+
+  it('should return false when nothing is focused', () => {
+    // Focus on body (default state)
+    document.body.focus();
+
+    expect(isInputElementFocused()).toBe(false);
+  });
+});

--- a/cmd/gui/frontend/src/lib/dom-utils.ts
+++ b/cmd/gui/frontend/src/lib/dom-utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Check if an input-like element is currently focused.
+ * Used to prevent keyboard shortcuts from interfering with text input.
+ */
+export function isInputElementFocused(): boolean {
+  const activeEl = document.activeElement;
+  return activeEl instanceof HTMLInputElement ||
+         activeEl instanceof HTMLTextAreaElement ||
+         activeEl?.getAttribute('contenteditable') === 'true';
+}


### PR DESCRIPTION
## Summary

- Add comprehensive keyboard navigation support for the GUI application
- Implement keyboard shortcuts for common actions across navigation panel and result table
- Add favorite view shortcuts (Cmd+1~9) for quick access

## Changes

### Keyboard Navigation
- **Tab**: Switch focus between navigation panel and result table
- **Arrow keys**: Navigate within focused panel (up/down for nav, all directions for table)
- **Space**: Toggle field selection (nav) or copy cell content (table)
- **Cmd+F**: Focus search in current panel
- **Cmd+Shift+A**: Clear all field selections
- **Cmd+1~9**: Quick apply favorite views (first 9 favorites show number badges)

### Bug Fixes
- Fix Cmd+F not working when nav search is visible but not focused
- Fix Cmd+F not toggling nav search closed properly
- Fix arrow/space keys not working in input fields (e.g., "Save as favorite" dialog)
- Remove duplicate Cmd+F handler that was conflicting between useTree and MainView

### UI Improvements
- Add KeymapBar component showing context-aware keyboard shortcuts
- Remove KeymapBar background color for better visual integration
- Replace Star icon with Kbd number badge for first 9 favorites

## Test plan

### Basic Navigation
- [x] Press `Tab` to switch focus between nav panel and result table
- [x] Verify focus ring appears on the focused panel
- [x] Press `Tab` again to switch back

### Navigation Panel Shortcuts
- [x] Focus nav panel, use `↑`/`↓` to navigate through fields
- [x] Press `Space` to toggle field selection
- [x] Press `Cmd+F` to open/toggle search bar
- [x] Type in search, verify field filtering works
- [x] Press `Esc` to close search
- [x] Press `Cmd+Shift+A` to clear all selected fields

### Result Table Shortcuts
- [x] Focus result table, use `↑`/`↓`/`←`/`→` to navigate cells
- [x] Press `Space` to copy focused cell content
- [x] Press `Cmd+F` to focus table search input

### Favorite Shortcuts
- [x] Save at least 2 favorites
- [x] Press `Cmd+1` to apply first favorite
- [x] Press `Cmd+2` to apply second favorite
- [x] Verify favorites work when nav panel is focused
- [x] Verify favorites work when result table is focused
- [x] Verify first 9 favorites show number badges instead of star icons

### Input Field Handling
- [x] Open "Save as favorite" popover
- [x] Type in name input, verify arrow keys move cursor (not navigate panel)
- [x] Verify space key types space character (not toggles selection)

### KeymapBar
- [x] Verify KeymapBar shows at bottom of screen
- [x] Verify shortcuts update based on focused panel
- [x] Verify shortcuts update when search input is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)