### PR TITLE
fix(gui): resolve search input keyboard issues and improve focus management

### DIFF
--- a/cmd/gui/frontend/src/App.jsx
+++ b/cmd/gui/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import { ColorPalette } from './components/debug/ColorPalette';
 import { AboutModal } from './components/AboutModal';
 import { Toaster } from './components/ui/sonner';
 import { ThemeProvider } from 'next-themes';
+import { isInputElementFocused } from './lib/dom-utils';
 
 function App() {
     const [showColors, setShowColors] = useState(false);
@@ -60,6 +61,12 @@ function App() {
             if ((e.metaKey || e.ctrlKey) && e.key === ']') {
                 e.preventDefault();
                 window.history.forward();
+            }
+
+            // Prevent Backspace from triggering browser history navigation
+            // when not focused on an input element (Wails WebView default behavior)
+            if (e.key === 'Backspace' && !isInputElementFocused()) {
+                e.preventDefault();
             }
         };
 

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -421,6 +421,7 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
                 selectedFields={selectedFields}
                 selectedGVK={selectedGVK}
                 connectedContexts={connectedContexts}
+                isTableFocused={focusedPanel === 'table'}
               />
             ) : (
               <div className="h-full flex items-center justify-center px-4">

--- a/cmd/gui/frontend/src/components/MainView.tsx
+++ b/cmd/gui/frontend/src/components/MainView.tsx
@@ -245,11 +245,8 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
         return;
       }
 
-      // Tab to switch panel focus
+      // Tab to switch panel focus (always works, even in search inputs)
       if (e.key === 'Tab' && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
-        // Don't handle Tab if any search input is focused
-        if (isNavSearchFocused() || isTableSearchFocused()) return;
-
         e.preventDefault();
         setFocusedPanel((prev) => {
           if (prev === 'nav') return 'table';
@@ -331,11 +328,13 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
           onExpand={() => setIsSidebarCollapsed(false)}
         >
           <div
-            className={`flex flex-col h-full transition-shadow ${
-              focusedPanel === 'nav' ? 'ring-2 ring-primary/50 ring-inset' : ''
-            }`}
+            className="flex flex-col h-full relative"
             onMouseDown={() => setFocusedPanel('nav')}
           >
+            {/* Focus overlay - renders above all content including sticky headers */}
+            {focusedPanel === 'nav' && (
+              <div className="absolute inset-0 ring-2 ring-primary/50 ring-inset pointer-events-none z-50" />
+            )}
             {/* Nav Header */}
             <NavHeader
               selectedContexts={selectedContexts}
@@ -394,11 +393,13 @@ export function MainView({ selectedContexts, connectedContexts, onBackToContexts
         {/* Right Panel - Main Content */}
         <ResizablePanel defaultSize={80}>
           <div
-            className={`h-full relative transition-shadow ${
-              focusedPanel === 'table' ? 'ring-2 ring-primary/50 ring-inset' : ''
-            }`}
+            className="h-full relative"
             onMouseDown={() => setFocusedPanel('table')}
           >
+            {/* Focus overlay - renders above all content including sticky headers */}
+            {focusedPanel === 'table' && (
+              <div className="absolute inset-0 ring-2 ring-primary/50 ring-inset pointer-events-none z-50" />
+            )}
             {/* Floating Expand Button (only when collapsed) */}
             {isSidebarCollapsed && (
               <Button

--- a/cmd/gui/frontend/src/components/ResultTable.test.tsx
+++ b/cmd/gui/frontend/src/components/ResultTable.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Tests for ResultTable component
+ *
+ * Focus on:
+ * - Cell focus cleared when isTableFocused becomes false (Tab to nav panel)
+ * - Cell focus cleared when mouse leaves table area
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ResultTable } from './ResultTable';
+
+// Mock data
+const mockData = [
+  { _context: 'ctx1', metadata: { name: 'pod-1', namespace: 'default' } },
+  { _context: 'ctx1', metadata: { name: 'pod-2', namespace: 'kube-system' } },
+  { _context: 'ctx1', metadata: { name: 'pod-3', namespace: 'default' } },
+];
+
+// Mock useResourceData hook
+vi.mock('../hooks/useResourceData', () => ({
+  useResourceData: vi.fn(() => ({
+    data: mockData,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    watchStatus: 'connected',
+    getRowId: (row: any) => `${row._context}/${row.metadata.namespace}/${row.metadata.name}`,
+    changedCells: [],
+  })),
+}));
+
+// Mock useFlashingCells hook
+vi.mock('../hooks/useFlashingCells', () => ({
+  useFlashingCells: vi.fn(() => ({
+    isFlashing: () => false,
+  })),
+}));
+
+// Mock useVirtualizer to render all rows (bypass virtualization in tests)
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: vi.fn(({ count }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({
+        index: i,
+        start: i * 28,
+        size: 28,
+        key: i,
+      })),
+    getTotalSize: () => count * 28,
+    scrollToIndex: vi.fn(),
+  })),
+}));
+
+// Mock Wails SaveFile function
+vi.mock('../../wailsjs/go/main/App', () => ({
+  SaveFile: vi.fn(),
+}));
+
+const defaultGVK = {
+  group: '',
+  version: 'v1',
+  kind: 'Pod',
+  contexts: ['ctx1'],
+  allCount: 1,
+};
+
+const defaultProps = {
+  selectedFields: [['metadata', 'namespace']],
+  selectedGVK: defaultGVK,
+  connectedContexts: ['ctx1'],
+  isTableFocused: true,
+};
+
+// Helper to find focused cells (CellContent uses underline class when focused)
+const getFocusedCellCount = () => {
+  // CellContent with isFocused=true has "underline bg-accent/50" class
+  return document.querySelectorAll('[class*="underline"][class*="bg-accent"]').length;
+};
+
+// Helper to find open popovers (CellContent popover opens when isFocused=true)
+const getOpenPopoverCount = () => {
+  return document.querySelectorAll('[data-state="open"]').length;
+};
+
+describe('ResultTable - Cell Focus Clear on Panel Switch', () => {
+  it('should clear cell focus when isTableFocused becomes false', async () => {
+    const { rerender } = render(<ResultTable {...defaultProps} isTableFocused={true} />);
+
+    // Wait for table to render
+    await waitFor(() => {
+      expect(screen.getByText('pod-1')).toBeInTheDocument();
+    });
+
+    // Hover over a cell to create focus
+    const cell = screen.getByText('pod-1');
+    fireEvent.mouseEnter(cell.closest('div[class*="px-4"]')!);
+
+    // The cell should show focused state (underline class)
+    expect(getFocusedCellCount()).toBeGreaterThan(0);
+
+    // Now simulate Tab to nav panel by changing isTableFocused to false
+    rerender(<ResultTable {...defaultProps} isTableFocused={false} />);
+
+    // After isTableFocused becomes false, cell focus should be cleared
+    expect(getFocusedCellCount()).toBe(0);
+  });
+
+  it('should not show cell focus when table panel is not focused', async () => {
+    render(<ResultTable {...defaultProps} isTableFocused={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('pod-1')).toBeInTheDocument();
+    });
+
+    // Initially no cells should be focused
+    expect(getFocusedCellCount()).toBe(0);
+  });
+});
+
+describe('ResultTable - Cell Focus Clear on Mouse Leave', () => {
+  it('should clear cell focus when mouse leaves table area', async () => {
+    render(<ResultTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('pod-1')).toBeInTheDocument();
+    });
+
+    // Find the table container (has overflow-auto class)
+    const tableContainer = document.querySelector('.overflow-auto');
+    expect(tableContainer).not.toBeNull();
+
+    // Hover over a cell to create focus
+    const cell = screen.getByText('pod-1');
+    fireEvent.mouseEnter(cell.closest('div[class*="px-4"]')!);
+
+    // Verify cell is focused
+    expect(getFocusedCellCount()).toBeGreaterThan(0);
+
+    // Mouse leave from table container
+    fireEvent.mouseLeave(tableContainer!);
+
+    // After mouse leave, cell focus should be cleared
+    expect(getFocusedCellCount()).toBe(0);
+  });
+});
+
+describe('ResultTable - Search Focus Clear', () => {
+  it('should clear cell focus when search input is focused', async () => {
+    render(<ResultTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('pod-1')).toBeInTheDocument();
+    });
+
+    // Hover over a cell to create focus
+    const cell = screen.getByText('pod-1');
+    fireEvent.mouseEnter(cell.closest('div[class*="px-4"]')!);
+
+    // Verify cell is focused
+    expect(getFocusedCellCount()).toBeGreaterThan(0);
+
+    // Focus the search input
+    const searchInput = screen.getByPlaceholderText('Search ...');
+    fireEvent.focus(searchInput);
+
+    // After search focus, cell focus should be cleared
+    expect(getFocusedCellCount()).toBe(0);
+  });
+});
+
+describe('ResultTable - Basic Rendering', () => {
+  it('should render table with data', async () => {
+    render(<ResultTable {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('pod-1')).toBeInTheDocument();
+      expect(screen.getByText('pod-2')).toBeInTheDocument();
+      expect(screen.getByText('pod-3')).toBeInTheDocument();
+    });
+  });
+
+  it('should render column headers', async () => {
+    render(<ResultTable {...defaultProps} />);
+
+    await waitFor(() => {
+      // Headers are uppercase
+      expect(screen.getByText('name')).toBeInTheDocument();
+      expect(screen.getByText('namespace')).toBeInTheDocument();
+    });
+  });
+
+  it('should render search toolbar', () => {
+    render(<ResultTable {...defaultProps} />);
+
+    expect(screen.getByPlaceholderText('Search ...')).toBeInTheDocument();
+  });
+});

--- a/cmd/gui/frontend/src/components/ResultTableToolbar.test.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Tests for ResultTableToolbar component
+ *
+ * Focus on:
+ * - Search input focus/blur triggers onSearchFocusChange callback
+ * - Keyboard events in search input don't propagate to parent
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ResultTableToolbar } from './ResultTableToolbar';
+
+// Mock Wails SaveFile function
+vi.mock('../../wailsjs/go/main/App', () => ({
+  SaveFile: vi.fn(),
+}));
+
+const defaultProps = {
+  globalFilter: '',
+  onGlobalFilterChange: vi.fn(),
+  filteredRowCount: 10,
+  totalRowCount: 100,
+  headers: ['name', 'namespace'],
+  rows: [['pod-1', 'default'], ['pod-2', 'kube-system']],
+  resourceKind: 'Pod',
+};
+
+describe('ResultTableToolbar - Search Focus Management', () => {
+  it('should call onSearchFocusChange(true) when search input is focused', async () => {
+    const onSearchFocusChange = vi.fn();
+
+    render(
+      <ResultTableToolbar
+        {...defaultProps}
+        onSearchFocusChange={onSearchFocusChange}
+      />
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search ...');
+    fireEvent.focus(searchInput);
+
+    expect(onSearchFocusChange).toHaveBeenCalledWith(true);
+  });
+
+  it('should call onSearchFocusChange(false) when search input loses focus', async () => {
+    const onSearchFocusChange = vi.fn();
+
+    render(
+      <ResultTableToolbar
+        {...defaultProps}
+        onSearchFocusChange={onSearchFocusChange}
+      />
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search ...');
+    fireEvent.focus(searchInput);
+    fireEvent.blur(searchInput);
+
+    expect(onSearchFocusChange).toHaveBeenCalledWith(false);
+  });
+
+  it('should not throw when onSearchFocusChange is not provided', () => {
+    render(<ResultTableToolbar {...defaultProps} />);
+
+    const searchInput = screen.getByPlaceholderText('Search ...');
+
+    // Should not throw
+    expect(() => {
+      fireEvent.focus(searchInput);
+      fireEvent.blur(searchInput);
+    }).not.toThrow();
+  });
+});
+
+describe('ResultTableToolbar - Keyboard Event Propagation', () => {
+  it('should stop keydown event propagation from search input', async () => {
+    const parentKeydownHandler = vi.fn();
+
+    const { container } = render(
+      <div onKeyDown={parentKeydownHandler}>
+        <ResultTableToolbar {...defaultProps} />
+      </div>
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search ...');
+
+    // Type in the search input
+    fireEvent.keyDown(searchInput, { key: 'a' });
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'ArrowUp' });
+    fireEvent.keyDown(searchInput, { key: 'Backspace' });
+
+    // Parent should NOT receive any keydown events
+    expect(parentKeydownHandler).not.toHaveBeenCalled();
+  });
+
+  it('should allow typing in search input without interference', async () => {
+    const user = userEvent.setup();
+    const onGlobalFilterChange = vi.fn();
+
+    render(
+      <ResultTableToolbar
+        {...defaultProps}
+        onGlobalFilterChange={onGlobalFilterChange}
+      />
+    );
+
+    const searchInput = screen.getByPlaceholderText('Search ...');
+
+    await user.type(searchInput, 'test');
+
+    // Each character should trigger onChange (controlled component)
+    expect(onGlobalFilterChange).toHaveBeenCalledTimes(4);
+    // Last call receives single character 't' because input value is controlled
+    expect(onGlobalFilterChange).toHaveBeenNthCalledWith(1, 't');
+    expect(onGlobalFilterChange).toHaveBeenNthCalledWith(2, 'e');
+    expect(onGlobalFilterChange).toHaveBeenNthCalledWith(3, 's');
+    expect(onGlobalFilterChange).toHaveBeenNthCalledWith(4, 't');
+  });
+});
+
+describe('ResultTableToolbar - Search Results Count', () => {
+  it('should show filtered count when search query is present', () => {
+    render(
+      <ResultTableToolbar
+        {...defaultProps}
+        globalFilter="pod"
+        filteredRowCount={5}
+        totalRowCount={100}
+      />
+    );
+
+    expect(screen.getByText('Found 5 / 100 rows')).toBeInTheDocument();
+  });
+
+  it('should not show filtered count when search query is empty', () => {
+    render(
+      <ResultTableToolbar
+        {...defaultProps}
+        globalFilter=""
+        filteredRowCount={100}
+        totalRowCount={100}
+      />
+    );
+
+    expect(screen.queryByText(/Found/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ResultTableToolbar - Export Button', () => {
+  it('should disable export button when rows are empty', () => {
+    render(
+      <ResultTableToolbar
+        {...defaultProps}
+        rows={[]}
+      />
+    );
+
+    const exportButton = screen.getByRole('button', { name: /export/i });
+    expect(exportButton).toBeDisabled();
+  });
+
+  it('should enable export button when rows are present', () => {
+    render(<ResultTableToolbar {...defaultProps} />);
+
+    const exportButton = screen.getByRole('button', { name: /export/i });
+    expect(exportButton).not.toBeDisabled();
+  });
+});

--- a/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
@@ -21,6 +21,7 @@ interface ResultTableToolbarProps {
   headers: string[];
   rows: any[][];
   resourceKind?: string; // For filename generation
+  onSearchFocusChange?: (focused: boolean) => void;
 }
 
 export interface ResultTableToolbarHandle {
@@ -38,6 +39,7 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
   headers,
   rows,
   resourceKind = 'resources',
+  onSearchFocusChange,
 }, ref) => {
   const [exporting, setExporting] = useState(false);
   const [exportStatus, setExportStatus] = useState<'idle' | 'copied' | 'downloaded' | 'error'>('idle');
@@ -113,6 +115,13 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
             placeholder="Search ..."
             value={globalFilter}
             onChange={(e) => onGlobalFilterChange(e.target.value)}
+            onKeyDown={(e) => {
+              // Prevent keydown events from propagating to MainView's global keymap
+              // This ensures typing in search doesn't trigger cell navigation or other shortcuts
+              e.stopPropagation();
+            }}
+            onFocus={() => onSearchFocusChange?.(true)}
+            onBlur={() => onSearchFocusChange?.(false)}
           />
           {globalFilter && (
             <p className="text-xs text-muted-foreground mt-2">


### PR DESCRIPTION
## Summary

- Fix keyboard input interruption when typing in ResultTable search input while a cell is focused
- Fix backspace key navigating back to context gallery unexpectedly
- Fix cell focus not clearing when mouse leaves table area or Tab switches to NavigationPanel
- Fix panel focus border being hidden behind sticky table headers
- Allow Tab key to switch panels even when search input is focused

## Test plan

- [x] Type in RT search input - keyboard should not be interrupted by cell focus
- [x] Press backspace outside of input fields - should not navigate back
- [x] Move mouse out of RT area - cell focus should clear
- [x] Press Tab to switch to NP - cell focus should clear
- [x] Focus border should appear above sticky headers in both panels
- [x] Press Tab while in NP search input - should switch to RT panel
- [x] All 173 frontend tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)