### PR TITLE
feat(ui): move resource count display to search bar right side

### DIFF
--- a/cmd/gui/frontend/src/components/ResultTableToolbar.test.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.test.tsx
@@ -120,7 +120,7 @@ describe('ResultTableToolbar - Keyboard Event Propagation', () => {
   });
 });
 
-describe('ResultTableToolbar - Search Results Count', () => {
+describe('ResultTableToolbar - Resource Count Display', () => {
   it('should show filtered count when search query is present', () => {
     render(
       <ResultTableToolbar
@@ -131,10 +131,10 @@ describe('ResultTableToolbar - Search Results Count', () => {
       />
     );
 
-    expect(screen.getByText('Found 5 / 100 rows')).toBeInTheDocument();
+    expect(screen.getByText('5/100 Pods')).toBeInTheDocument();
   });
 
-  it('should not show filtered count when search query is empty', () => {
+  it('should show total count when search query is empty', () => {
     render(
       <ResultTableToolbar
         {...defaultProps}
@@ -144,7 +144,7 @@ describe('ResultTableToolbar - Search Results Count', () => {
       />
     );
 
-    expect(screen.queryByText(/Found/)).not.toBeInTheDocument();
+    expect(screen.getByText('100 Pods')).toBeInTheDocument();
   });
 });
 

--- a/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
@@ -112,8 +112,8 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
   return (
     <div className="p-4 border-b border-border">
       <div className="flex items-center justify-between gap-4">
-        {/* Left: Search input */}
-        <div className="flex-1 max-w-sm">
+        {/* Left: Search input with resource count */}
+        <div className="flex items-center gap-3 flex-1 max-w-md">
           <Input
             ref={searchInputRef}
             placeholder="Search ..."
@@ -126,12 +126,14 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
             }}
             onFocus={() => onSearchFocusChange?.(true)}
             onBlur={() => onSearchFocusChange?.(false)}
+            className="flex-1"
           />
-          {globalFilter && (
-            <p className="text-xs text-muted-foreground mt-2">
-              Found {filteredRowCount} / {totalRowCount} rows
-            </p>
-          )}
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {globalFilter
+              ? `${filteredRowCount}/${totalRowCount} ${resourceKind}s`
+              : `${totalRowCount} ${resourceKind}s`
+            }
+          </span>
         </div>
 
         {/* Right: Export button */}

--- a/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
+++ b/cmd/gui/frontend/src/components/ResultTableToolbar.tsx
@@ -113,7 +113,7 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
     <div className="p-4 border-b border-border">
       <div className="flex items-center justify-between gap-4">
         {/* Left: Search input with resource count */}
-        <div className="flex items-center gap-3 flex-1 max-w-md">
+        <div className="flex items-center gap-3">
           <Input
             ref={searchInputRef}
             placeholder="Search ..."
@@ -126,7 +126,7 @@ export const ResultTableToolbar = forwardRef<ResultTableToolbarHandle, ResultTab
             }}
             onFocus={() => onSearchFocusChange?.(true)}
             onBlur={() => onSearchFocusChange?.(false)}
-            className="flex-1"
+            className="w-48 h-8 py-1 px-2"
           />
           <span className="text-sm text-muted-foreground whitespace-nowrap">
             {globalFilter


### PR DESCRIPTION
## Summary
- Always show resource count next to search input (not just when filtering)
- Move display from below search input to inline right side
- Format: `n/m {Kind}s` when filtering, `{m} {Kind}s` when not

## Before / After

| Before | After |
|--------|-------|
| Only shown when searching, below input | Always visible, inline right side |
| `Found 23 / 156 rows` | `23/156 Pods` or `156 Pods` |

## Test plan
- [x] Verify resource count displays when no search filter is applied
- [x] Verify filtered/total count displays when search filter is active
- [x] Verify resource kind is pluralized correctly

🤖 Generated with [Claude Code](https://claude.ai/code)