### PR TITLE
feat(gui): auto-select additionalPrinterColumns for CRD resources

### DIFF
--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -297,7 +297,7 @@ func (a *App) GetNodeTree(gvk MultiClusterGVK, contexts []string) ([]*TreeNode, 
 
 // GetDefaultSelectedPaths returns the default fields to select for a GVK.
 // For CRDs, this returns paths from additionalPrinterColumns.
-// For built-in resources, returns nil (no default selection beyond metadata.name).
+// For built-in resources, this uses Table API printer columns when available.
 func (a *App) GetDefaultSelectedPaths(gvk MultiClusterGVK, contexts []string) [][]string {
 	schemaGVK := schema.GroupVersionKind{
 		Group:   gvk.Group,

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -295,6 +295,35 @@ func (a *App) GetNodeTree(gvk MultiClusterGVK, contexts []string) ([]*TreeNode, 
 	return convertNodeTree(nodes), nil
 }
 
+// GetDefaultSelectedPaths returns the default fields to select for a GVK.
+// For CRDs, this returns paths from additionalPrinterColumns.
+// For built-in resources, returns nil (no default selection beyond metadata.name).
+func (a *App) GetDefaultSelectedPaths(gvk MultiClusterGVK, contexts []string) [][]string {
+	schemaGVK := schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+	}
+
+	// Try each context until we get printer columns
+	for _, contextName := range contexts {
+		paths, err := kube.GetPrinterColumnsForContext(contextName, schemaGVK)
+		if err == nil && len(paths) > 0 {
+			return paths
+		}
+	}
+
+	// Also try with contexts from GVK if different
+	for _, contextName := range gvk.Contexts {
+		paths, err := kube.GetPrinterColumnsForContext(contextName, schemaGVK)
+		if err == nil && len(paths) > 0 {
+			return paths
+		}
+	}
+
+	return nil
+}
+
 // getWatchedResources returns resources from active watch controllers if available
 func (a *App) getWatchedResources() []*unstructured.Unstructured {
 	a.watchMu.RLock()

--- a/cmd/gui/frontend/src/components/NavigationPanel.test.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.test.tsx
@@ -8,6 +8,7 @@ import * as App from '../../wailsjs/go/main/App';
 // Mock the Wails API
 vi.mock('../../wailsjs/go/main/App', () => ({
   GetNodeTree: vi.fn(),
+  GetDefaultSelectedPaths: vi.fn(() => Promise.resolve(null)),
 }));
 
 // Mock the Wails runtime (for EventsOn used by watch)

--- a/cmd/gui/frontend/wailsjs/go/main/App.d.ts
+++ b/cmd/gui/frontend/wailsjs/go/main/App.d.ts
@@ -8,6 +8,8 @@ export function DeleteFavoriteView(arg1:string):Promise<void>;
 
 export function GetCurrentContext():Promise<string>;
 
+export function GetDefaultSelectedPaths(arg1:main.MultiClusterGVK,arg2:Array<string>):Promise<Array<Array<string>>>;
+
 export function GetFavoriteViewsForGVK(arg1:string,arg2:string,arg3:string):Promise<Array<main.FavoriteViewResponse>>;
 
 export function GetGVKs(arg1:Array<string>):Promise<Array<main.MultiClusterGVK>>;

--- a/cmd/gui/frontend/wailsjs/go/main/App.d.ts
+++ b/cmd/gui/frontend/wailsjs/go/main/App.d.ts
@@ -8,7 +8,7 @@ export function DeleteFavoriteView(arg1:string):Promise<void>;
 
 export function GetCurrentContext():Promise<string>;
 
-export function GetDefaultSelectedPaths(arg1:main.MultiClusterGVK,arg2:Array<string>):Promise<Array<Array<string>>>;
+export function GetDefaultSelectedPaths(arg1:main.MultiClusterGVK,arg2:Array<string>):Promise<Array<any>>;
 
 export function GetFavoriteViewsForGVK(arg1:string,arg2:string,arg3:string):Promise<Array<main.FavoriteViewResponse>>;
 

--- a/cmd/gui/frontend/wailsjs/go/main/App.js
+++ b/cmd/gui/frontend/wailsjs/go/main/App.js
@@ -14,6 +14,10 @@ export function GetCurrentContext() {
   return window['go']['main']['App']['GetCurrentContext']();
 }
 
+export function GetDefaultSelectedPaths(arg1, arg2) {
+  return window['go']['main']['App']['GetDefaultSelectedPaths'](arg1, arg2);
+}
+
 export function GetFavoriteViewsForGVK(arg1, arg2, arg3) {
   return window['go']['main']['App']['GetFavoriteViewsForGVK'](arg1, arg2, arg3);
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/sahilm/fuzzy v0.1.1
+	github.com/stretchr/testify v1.10.0
 	github.com/wailsapp/wails/v2 v2.11.0
 	k8s.io/apimachinery v0.34.2
 	k8s.io/client-go v0.34.2
@@ -104,6 +105,7 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.34.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -196,47 +195,6 @@ func DiscoveryClientForContext(contextName string) (discovery.DiscoveryInterface
 		return nil, err
 	}
 	return cs.Discovery(), nil
-}
-
-// RESTClientForContext returns a REST client for the specified context and GVR
-// If contextName is empty, uses the current context
-func RESTClientForContext(contextName string, gvr schema.GroupVersionResource) (rest.Interface, error) {
-	cs, err := clientSetForContext(contextName)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return appropriate REST client based on group
-	switch gvr.Group {
-	case "":
-		return cs.CoreV1().RESTClient(), nil
-	case "apps":
-		return cs.AppsV1().RESTClient(), nil
-	case "batch":
-		return cs.BatchV1().RESTClient(), nil
-	case "networking.k8s.io":
-		return cs.NetworkingV1().RESTClient(), nil
-	case "storage.k8s.io":
-		return cs.StorageV1().RESTClient(), nil
-	case "rbac.authorization.k8s.io":
-		return cs.RbacV1().RESTClient(), nil
-	case "autoscaling":
-		return cs.AutoscalingV1().RESTClient(), nil
-	case "policy":
-		return cs.PolicyV1().RESTClient(), nil
-	case "coordination.k8s.io":
-		return cs.CoordinationV1().RESTClient(), nil
-	case "scheduling.k8s.io":
-		return cs.SchedulingV1().RESTClient(), nil
-	case "admissionregistration.k8s.io":
-		return cs.AdmissionregistrationV1().RESTClient(), nil
-	case "apiextensions.k8s.io":
-		// For CRDs, we need to use the discovery or dynamic client
-		return nil, fmt.Errorf("apiextensions.k8s.io not supported via REST client")
-	default:
-		// For unknown groups, return core v1 as fallback
-		return cs.CoreV1().RESTClient(), nil
-	}
 }
 
 // TryTshKubeLogin attempts to run tsh kube login for a context

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -195,6 +196,47 @@ func DiscoveryClientForContext(contextName string) (discovery.DiscoveryInterface
 		return nil, err
 	}
 	return cs.Discovery(), nil
+}
+
+// RESTClientForContext returns a REST client for the specified context and GVR
+// If contextName is empty, uses the current context
+func RESTClientForContext(contextName string, gvr schema.GroupVersionResource) (rest.Interface, error) {
+	cs, err := clientSetForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return appropriate REST client based on group
+	switch gvr.Group {
+	case "":
+		return cs.CoreV1().RESTClient(), nil
+	case "apps":
+		return cs.AppsV1().RESTClient(), nil
+	case "batch":
+		return cs.BatchV1().RESTClient(), nil
+	case "networking.k8s.io":
+		return cs.NetworkingV1().RESTClient(), nil
+	case "storage.k8s.io":
+		return cs.StorageV1().RESTClient(), nil
+	case "rbac.authorization.k8s.io":
+		return cs.RbacV1().RESTClient(), nil
+	case "autoscaling":
+		return cs.AutoscalingV1().RESTClient(), nil
+	case "policy":
+		return cs.PolicyV1().RESTClient(), nil
+	case "coordination.k8s.io":
+		return cs.CoordinationV1().RESTClient(), nil
+	case "scheduling.k8s.io":
+		return cs.SchedulingV1().RESTClient(), nil
+	case "admissionregistration.k8s.io":
+		return cs.AdmissionregistrationV1().RESTClient(), nil
+	case "apiextensions.k8s.io":
+		// For CRDs, we need to use the discovery or dynamic client
+		return nil, fmt.Errorf("apiextensions.k8s.io not supported via REST client")
+	default:
+		// For unknown groups, return core v1 as fallback
+		return cs.CoreV1().RESTClient(), nil
+	}
 }
 
 // TryTshKubeLogin attempts to run tsh kube login for a context

--- a/internal/kube/printer_columns_test.go
+++ b/internal/kube/printer_columns_test.go
@@ -1,0 +1,63 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGetPrinterColumnsForContext_BuiltInResources(t *testing.T) {
+	// Skip if no cluster available
+	_, err := GetCurrentContext()
+	if err != nil {
+		t.Skip("No Kubernetes cluster available")
+	}
+
+	testCases := []struct {
+		name     string
+		gvk      schema.GroupVersionKind
+		expected [][]string
+	}{
+		{
+			name:     "Pod",
+			gvk:      schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			expected: [][]string{{"status", "phase"}, {"metadata", "creationTimestamp"}},
+		},
+		{
+			name:     "Deployment",
+			gvk:      schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			expected: [][]string{{"status", "readyReplicas"}, {"status", "updatedReplicas"}, {"status", "availableReplicas"}, {"metadata", "creationTimestamp"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			paths, err := GetPrinterColumnsForContext("", tc.gvk)
+			assert.NoError(t, err)
+			assert.NotNil(t, paths, "Expected paths but got nil")
+			t.Logf("Got paths for %s: %v", tc.name, paths)
+			
+			// Check that expected paths are present
+			for _, expected := range tc.expected {
+				found := false
+				for _, path := range paths {
+					if len(path) == len(expected) {
+						match := true
+						for i := range path {
+							if path[i] != expected[i] {
+								match = false
+								break
+							}
+						}
+						if match {
+							found = true
+							break
+						}
+					}
+				}
+				assert.True(t, found, "Expected path %v not found in %v", expected, paths)
+			}
+		})
+	}
+}

--- a/internal/kube/printer_columns_test.go
+++ b/internal/kube/printer_columns_test.go
@@ -42,7 +42,7 @@ func TestGetPrinterColumnsForContext_BuiltInResources(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, paths, "Expected paths but got nil")
 			t.Logf("Got paths for %s: %v", tc.name, paths)
-			
+
 			// Check that expected paths are present
 			for _, expected := range tc.expected {
 				found := false

--- a/internal/kube/printer_columns_test.go
+++ b/internal/kube/printer_columns_test.go
@@ -8,10 +8,15 @@ import (
 )
 
 func TestGetPrinterColumnsForContext_BuiltInResources(t *testing.T) {
-	// Skip if no cluster available
-	_, err := GetCurrentContext()
+	// Skip if no cluster available - try actual API call to verify connectivity
+	dc, err := DiscoveryClientForContext("")
 	if err != nil {
-		t.Skip("No Kubernetes cluster available")
+		t.Skip("No Kubernetes cluster available: " + err.Error())
+	}
+	// Try to get server version to verify actual connectivity
+	_, err = dc.ServerVersion()
+	if err != nil {
+		t.Skip("Cannot connect to Kubernetes cluster: " + err.Error())
 	}
 
 	testCases := []struct {

--- a/internal/kube/resource.go
+++ b/internal/kube/resource.go
@@ -96,7 +96,9 @@ func (i *ResourceController) Context() string {
 func (i *ResourceController) Objects() []*unstructured.Unstructured {
 	objs := make([]*unstructured.Unstructured, 0)
 	for _, obj := range i.store.List() {
-		objs = append(objs, obj.(*unstructured.Unstructured))
+		// DeepCopy to avoid concurrent map read/write panic
+		// The informer's watch goroutine may be modifying objects while we read them
+		objs = append(objs, obj.(*unstructured.Unstructured).DeepCopy())
 	}
 	sort.Slice(objs, func(i, j int) bool {
 		// TODO: sort by namespace if gvr is namespaced

--- a/internal/kube/resource.go
+++ b/internal/kube/resource.go
@@ -152,7 +152,7 @@ func (i *ResourceController) Inform() (chan struct{}, error) {
 				if !ok {
 					return
 				}
-				// Update cached name (in case of rename, though rare)
+				// Update cached name for this key, since the object reference may change
 				key, _ := cache.MetaNamespaceKeyFunc(n)
 				i.nameCacheMu.Lock()
 				i.nameCache[key] = n.GetName()

--- a/internal/kube/resource.go
+++ b/internal/kube/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"sync"
 	"sync/atomic"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,6 +61,11 @@ type ResourceController struct {
 	emitCh      chan emitMsg
 	doneCh      chan struct{} // signals that controller is closed (for event consumers)
 	closed      atomic.Bool   // guards trySend to prevent sends after close
+
+	// nameCache stores object names by key to avoid race conditions during sorting.
+	// Updated synchronously by informer handlers, read by Objects().
+	nameCache   map[string]string
+	nameCacheMu sync.RWMutex
 }
 
 // NewResourceController creates a controller for the current context (legacy, kept for TUI compatibility)
@@ -85,6 +91,7 @@ func NewResourceControllerForContext(contextName string, gvr schema.GroupVersion
 		gvr:         gvr,
 		emitCh:      make(chan emitMsg, 256),
 		doneCh:      make(chan struct{}),
+		nameCache:   make(map[string]string),
 	}
 }
 
@@ -96,14 +103,20 @@ func (i *ResourceController) Context() string {
 func (i *ResourceController) Objects() []*unstructured.Unstructured {
 	objs := make([]*unstructured.Unstructured, 0)
 	for _, obj := range i.store.List() {
-		// DeepCopy to avoid concurrent map read/write panic
-		// The informer's watch goroutine may be modifying objects while we read them
-		objs = append(objs, obj.(*unstructured.Unstructured).DeepCopy())
+		objs = append(objs, obj.(*unstructured.Unstructured))
 	}
-	sort.Slice(objs, func(i, j int) bool {
-		// TODO: sort by namespace if gvr is namespaced
-		return objs[i].GetName() < objs[j].GetName()
+
+	// Use cached names for sorting to avoid race conditions.
+	// The nameCache is updated synchronously by informer handlers.
+	// Hold read lock during sort to prevent writes while sorting.
+	i.nameCacheMu.RLock()
+	sort.Slice(objs, func(a, b int) bool {
+		keyA, _ := cache.MetaNamespaceKeyFunc(objs[a])
+		keyB, _ := cache.MetaNamespaceKeyFunc(objs[b])
+		return i.nameCache[keyA] < i.nameCache[keyB]
 	})
+	i.nameCacheMu.RUnlock()
+
 	return objs
 }
 
@@ -126,6 +139,12 @@ func (i *ResourceController) Inform() (chan struct{}, error) {
 				if !ok {
 					return
 				}
+				// Cache the name for race-free sorting in Objects()
+				key, _ := cache.MetaNamespaceKeyFunc(u)
+				i.nameCacheMu.Lock()
+				i.nameCache[key] = u.GetName()
+				i.nameCacheMu.Unlock()
+
 				i.trySend(emitMsg{Type: EventAdded, Obj: u})
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
@@ -133,10 +152,17 @@ func (i *ResourceController) Inform() (chan struct{}, error) {
 				if !ok {
 					return
 				}
+				// Update cached name (in case of rename, though rare)
+				key, _ := cache.MetaNamespaceKeyFunc(n)
+				i.nameCacheMu.Lock()
+				i.nameCache[key] = n.GetName()
+				i.nameCacheMu.Unlock()
+
 				i.trySend(emitMsg{Type: EventModified, Obj: n})
 			},
 			DeleteFunc: func(obj interface{}) {
 				var d *unstructured.Unstructured
+				var key string
 
 				// Handle DeletedFinalStateUnknown wrapper
 				if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
@@ -144,13 +170,21 @@ func (i *ResourceController) Inform() (chan struct{}, error) {
 					if !ok {
 						return
 					}
+					key = deleted.Key
 				} else {
 					var ok bool
 					d, ok = obj.(*unstructured.Unstructured)
 					if !ok {
 						return
 					}
+					key, _ = cache.MetaNamespaceKeyFunc(d)
 				}
+
+				// Remove from name cache
+				i.nameCacheMu.Lock()
+				delete(i.nameCache, key)
+				i.nameCacheMu.Unlock()
+
 				i.trySend(emitMsg{Type: EventDeleted, Obj: d})
 			},
 		},

--- a/internal/kube/resource_test.go
+++ b/internal/kube/resource_test.go
@@ -1,6 +1,8 @@
 package kube
 
 import (
+	"sync"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -165,6 +167,130 @@ var _ = Describe("ResourceController", func() {
 				// Should not emit anything
 				Consistently(emitCh).ShouldNot(Receive())
 			})
+		})
+	})
+
+	// Regression test for concurrent map read/write panic
+	// This test verifies that Objects() uses cached names for sorting,
+	// preventing race conditions when accessing object metadata during sort.
+	Describe("Objects", func() {
+		It("should sort objects using cached names", func() {
+			// Create a fake store
+			store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+
+			// Create a controller with the fake store and nameCache
+			controller := &ResourceController{
+				store:     store,
+				nameCache: make(map[string]string),
+			}
+
+			// Add objects to store and populate nameCache
+			obj1 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":      "zebra-pod",
+						"namespace": "default",
+					},
+				},
+			}
+			obj2 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":      "alpha-pod",
+						"namespace": "default",
+					},
+				},
+			}
+
+			Expect(store.Add(obj1)).To(Succeed())
+			Expect(store.Add(obj2)).To(Succeed())
+
+			// Populate nameCache (simulating what informer handlers do)
+			key1, _ := cache.MetaNamespaceKeyFunc(obj1)
+			key2, _ := cache.MetaNamespaceKeyFunc(obj2)
+			controller.nameCache[key1] = obj1.GetName()
+			controller.nameCache[key2] = obj2.GetName()
+
+			// Get objects via controller - should be sorted by name
+			objs := controller.Objects()
+			Expect(objs).To(HaveLen(2))
+
+			// Verify sorting order (alpha-pod should come before zebra-pod)
+			Expect(objs[0].GetName()).To(Equal("alpha-pod"))
+			Expect(objs[1].GetName()).To(Equal("zebra-pod"))
+		})
+
+		It("should handle concurrent reads and writes safely", func() {
+			// Create a fake store with multiple objects
+			store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+			controller := &ResourceController{
+				store:     store,
+				nameCache: make(map[string]string),
+			}
+
+			// Add objects to store and populate nameCache
+			for i := 0; i < 50; i++ {
+				name := "pod-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Pod",
+						"metadata": map[string]interface{}{
+							"name":      name,
+							"namespace": "default",
+						},
+					},
+				}
+				Expect(store.Add(obj)).To(Succeed())
+
+				// Populate nameCache
+				key, _ := cache.MetaNamespaceKeyFunc(obj)
+				controller.nameCacheMu.Lock()
+				controller.nameCache[key] = name
+				controller.nameCacheMu.Unlock()
+			}
+
+			// Multiple goroutines calling Objects() and simulating informer updates
+			var wg sync.WaitGroup
+
+			// Reader goroutines
+			for i := 0; i < 5; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+					for j := 0; j < 100; j++ {
+						objs := controller.Objects()
+						// Access each object's fields (read operations)
+						for _, obj := range objs {
+							_ = obj.GetName()
+							_ = obj.GetNamespace()
+						}
+					}
+				}()
+			}
+
+			// Writer goroutines (simulating informer update handlers)
+			for i := 0; i < 5; i++ {
+				wg.Add(1)
+				go func(id int) {
+					defer wg.Done()
+					defer GinkgoRecover()
+					for j := 0; j < 100; j++ {
+						// Simulate nameCache update (like informer handlers do)
+						key := "default/pod-update-" + string(rune('0'+id))
+						controller.nameCacheMu.Lock()
+						controller.nameCache[key] = "updated-name-" + string(rune('0'+j%10))
+						controller.nameCacheMu.Unlock()
+					}
+				}(i)
+			}
+
+			wg.Wait()
 		})
 	})
 })

--- a/internal/kube/schema.go
+++ b/internal/kube/schema.go
@@ -559,8 +559,7 @@ func mapColumnNameToFieldPath(columnName string, kind string) []string {
 			// - "Access Modes": spec.accessModes (array)
 		},
 		"StatefulSet": {
-			"Ready":    {"status", "readyReplicas"},
-			"Replicas": {"spec", "replicas"},
+			"Ready": {"status", "readyReplicas"},
 			// EXCLUDED:
 			// - "Containers": computed from spec.template.spec.containers[].name
 			// - "Images": computed from spec.template.spec.containers[].image

--- a/internal/kube/schema_test.go
+++ b/internal/kube/schema_test.go
@@ -1,0 +1,63 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJsonPathToFieldPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonPath string
+		expected []string
+	}{
+		{
+			name:     "simple path",
+			jsonPath: ".spec.replicas",
+			expected: []string{"spec", "replicas"},
+		},
+		{
+			name:     "nested path",
+			jsonPath: ".status.conditions.type",
+			expected: []string{"status", "conditions", "type"},
+		},
+		{
+			name:     "path with array index",
+			jsonPath: ".status.conditions[0].type",
+			expected: []string{"status", "conditions", "*", "type"},
+		},
+		{
+			name:     "metadata path",
+			jsonPath: ".metadata.creationTimestamp",
+			expected: []string{"metadata", "creationTimestamp"},
+		},
+		{
+			name:     "empty path",
+			jsonPath: "",
+			expected: nil,
+		},
+		{
+			name:     "single field",
+			jsonPath: ".status",
+			expected: []string{"status"},
+		},
+		{
+			name:     "without leading dot",
+			jsonPath: "spec.replicas",
+			expected: []string{"spec", "replicas"},
+		},
+		{
+			name:     "path with multiple array indices",
+			jsonPath: ".spec.containers[0].ports[0].containerPort",
+			expected: []string{"spec", "containers", "*", "ports", "*", "containerPort"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := jsonPathToFieldPath(tt.jsonPath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Auto-select fields defined in CRD's additionalPrinterColumns when selecting a CRD resource type
- Auto-select fields for built-in resources (Pod, Deployment, etc.) using Kubernetes Table API
- Only maps to scalar/leaf fields that can be directly selected in the schema tree
- Computed columns (calculated from multiple fields or arrays) are intentionally excluded

## Changes
### Backend
- `GetPrinterColumnsForContext`: Extract additionalPrinterColumns from CRD definitions
- `getPrinterColumnsFromTableAPI`: Fetch column definitions from Kubernetes Table API for built-in resources
- `mapColumnNameToFieldPath`: Map Table API column names to field paths (with documented exclusions)
- `jsonPathToFieldPath`: Convert JSONPath to field path (`.spec.replicas` → `["spec", "replicas"]`)
- `GetDefaultSelectedPaths`: Frontend-facing API method

### Frontend
- Call `GetDefaultSelectedPaths` when GVK is selected to auto-select default fields

## Test plan
- [x] Go backend tests pass (`go test ./internal/kube/...`)
- [x] TypeScript type check passes (`npm run type-check`)
- [x] Frontend unit tests pass (`npm test`)
- [x] Manual test with CRD resources (e.g., cert-manager Certificate)
- [x] Manual test with built-in resources (see checklist below)

---

## Manual Test Checklist for Built-in Resources

### Common (all resources)
- [x] metadata.creationTimestamp
- [ ] metadata.namespace -- isn't selected but ignore for a less verbosity
- [ ] metadata.labels

### Pod
- [x] status.phase
- [x] status.podIP
- [x] spec.nodeName

Excluded: Ready, Restarts, Nominated Node, Readiness Gates

### Deployment
- [x] status.readyReplicas
- [x] status.updatedReplicas
- [x] status.availableReplicas

Excluded: Containers, Images, Selector

### Service
- [x] spec.type
- [x] spec.clusterIP

Excluded: External-IP, Port(s), Selector

### ConfigMap
- [x] data

### Secret
- [x] type
- [x] data

### Node
- [x] status.nodeInfo.kubeletVersion
- [x] status.nodeInfo.osImage
- [x] status.nodeInfo.kernelVersion
- [x] status.nodeInfo.containerRuntimeVersion

Excluded: Status, Roles, Internal-IP, External-IP

### Namespace
- [x] status.phase

### PersistentVolume
- [x] spec.persistentVolumeReclaimPolicy
- [x] status.phase
- [x] spec.storageClassName
- [x] status.reason

Excluded: Capacity, Access Modes, Claim

### PersistentVolumeClaim
- [x] status.phase
- [x] spec.volumeName
- [x] spec.storageClassName

Excluded: Capacity, Access Modes

### StatefulSet
- [x] status.readyReplicas

Excluded: Replicas (Table API does not have this column), Containers, Images

### DaemonSet
- [x] status.desiredNumberScheduled
- [x] status.currentNumberScheduled
- [x] status.numberReady
- [x] status.updatedNumberScheduled
- [x] status.numberAvailable

Excluded: Node Selector, Containers, Images

### ReplicaSet
- [x] spec.replicas
- [x] status.replicas
- [x] status.readyReplicas

Excluded: Containers, Images, Selector

### Job
- [x] spec.completions
- [x] status.completionTime

Excluded: Status, Containers, Images, Selector

### CronJob
- [x] spec.schedule
- [x] spec.suspend
- [x] status.lastScheduleTime

Excluded: Active, Containers, Images

### Ingress
- [x] spec.ingressClassName

Excluded: Hosts, Address, Ports

---

Generated with [Claude Code](https://claude.ai/code)