### PR TITLE
feat(nav): add wildcard (*) node for bulk selection of child fields

### DIFF
--- a/cmd/gui/frontend/src/components/NavigationPanel.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.tsx
@@ -47,6 +47,8 @@ interface TreeNodeItemProps {
   shouldAutoScroll?: boolean;
   /** Path highlighted from ResultTable hover */
   highlightedFieldPathKey?: string;
+  /** Paths of wildcard nodes that are in indeterminate state */
+  wildcardIndeterminatePaths: Set<string>;
 }
 
 // Memoized TreeNode component to prevent unnecessary re-renders
@@ -61,6 +63,7 @@ const TreeNodeItem = memo(({
   onFocus,
   shouldAutoScroll = false,
   highlightedFieldPathKey,
+  wildcardIndeterminatePaths,
 }: TreeNodeItemProps) => {
   const hasChildren = node.children && node.children.length > 0;
   const isArrayOrMap = node.type && (node.type.startsWith('[]') || node.type.startsWith('map['));
@@ -125,7 +128,14 @@ const TreeNodeItem = memo(({
       >
 
         {/* Expand/Collapse button OR Checkbox (mutually exclusive) */}
-        {hasChildren ? (
+        {/* Map wildcard (*) node: leaf-like, shows checkbox for selecting all siblings */}
+        {node.name === '*' && !hasChildren ? (
+          <Checkbox
+            checked={wildcardIndeterminatePaths.has(pathKey) ? 'indeterminate' : selected}
+            onCheckedChange={handleSelectChange}
+            className="mr-1.5 h-3.5 w-3.5 shrink-0"
+          />
+        ) : hasChildren ? (
           <Button
             variant="ghost"
             size="icon"
@@ -183,6 +193,7 @@ const TreeNodeItem = memo(({
               onFocus={onFocus}
               shouldAutoScroll={shouldAutoScroll}
               highlightedFieldPathKey={highlightedFieldPathKey}
+              wildcardIndeterminatePaths={wildcardIndeterminatePaths}
             />
           ))}
         </div>
@@ -227,6 +238,7 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
     toggleSelect,
     clearAllSelections,
     setSelectionsFromPaths,
+    wildcardIndeterminatePaths,
 
     // Keyboard navigation
     focusedPathKey,
@@ -343,6 +355,7 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
                   (Boolean(debouncedQuery) && matchedPaths.length > 0)
                 }
                 highlightedFieldPathKey={highlightedFieldPathKey}
+                wildcardIndeterminatePaths={wildcardIndeterminatePaths}
               />
             ))}
           </div>

--- a/cmd/gui/frontend/src/components/NavigationPanel.tsx
+++ b/cmd/gui/frontend/src/components/NavigationPanel.tsx
@@ -47,8 +47,10 @@ interface TreeNodeItemProps {
   shouldAutoScroll?: boolean;
   /** Path highlighted from ResultTable hover */
   highlightedFieldPathKey?: string;
-  /** Paths of wildcard nodes that are in indeterminate state */
+  /** Paths of wildcard child fields that are in indeterminate state */
   wildcardIndeterminatePaths: Set<string>;
+  /** Paths of wildcard child fields where all indexed siblings are selected */
+  wildcardSelectedPaths: Set<string>;
 }
 
 // Memoized TreeNode component to prevent unnecessary re-renders
@@ -64,6 +66,7 @@ const TreeNodeItem = memo(({
   shouldAutoScroll = false,
   highlightedFieldPathKey,
   wildcardIndeterminatePaths,
+  wildcardSelectedPaths,
 }: TreeNodeItemProps) => {
   const hasChildren = node.children && node.children.length > 0;
   const isArrayOrMap = node.type && (node.type.startsWith('[]') || node.type.startsWith('map['));
@@ -73,6 +76,9 @@ const TreeNodeItem = memo(({
   const isDefaultColumn = DEFAULT_SCHEMA_FIELDS.includes(node.fullPath.join('.') as typeof DEFAULT_SCHEMA_FIELDS[number]);
   const expanded = expandedPaths.has(pathKey);
   const selected = selectedPaths.has(pathKey);
+  // For wildcard child fields: check if all indexed siblings are selected or partially selected
+  const isWildcardSelected = wildcardSelectedPaths.has(pathKey);
+  const isWildcardIndeterminate = wildcardIndeterminatePaths.has(pathKey);
   const matchIndices = searchResultsMap.get(pathKey);
   const hasHighlight = matchIndices !== undefined && matchIndices !== null && matchIndices.length > 0;
   const isFocused = focusedPath === pathKey;
@@ -131,7 +137,7 @@ const TreeNodeItem = memo(({
         {/* Map wildcard (*) node: leaf-like, shows checkbox for selecting all siblings */}
         {node.name === '*' && !hasChildren ? (
           <Checkbox
-            checked={wildcardIndeterminatePaths.has(pathKey) ? 'indeterminate' : selected}
+            checked={isWildcardIndeterminate ? 'indeterminate' : (selected || isWildcardSelected)}
             onCheckedChange={handleSelectChange}
             className="mr-1.5 h-3.5 w-3.5 shrink-0"
           />
@@ -150,7 +156,11 @@ const TreeNodeItem = memo(({
           </Button>
         ) : isLeaf ? (
           <Checkbox
-            checked={isDefaultColumn || selected}
+            checked={
+              isDefaultColumn ? true :
+              isWildcardIndeterminate ? 'indeterminate' :
+              (selected || isWildcardSelected)
+            }
             onCheckedChange={handleSelectChange}
             disabled={isDefaultColumn}
             className="mr-1.5 h-3.5 w-3.5 shrink-0"
@@ -194,6 +204,7 @@ const TreeNodeItem = memo(({
               shouldAutoScroll={shouldAutoScroll}
               highlightedFieldPathKey={highlightedFieldPathKey}
               wildcardIndeterminatePaths={wildcardIndeterminatePaths}
+              wildcardSelectedPaths={wildcardSelectedPaths}
             />
           ))}
         </div>
@@ -239,6 +250,7 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
     clearAllSelections,
     setSelectionsFromPaths,
     wildcardIndeterminatePaths,
+    wildcardSelectedPaths,
 
     // Keyboard navigation
     focusedPathKey,
@@ -356,6 +368,7 @@ export const NavigationPanel = forwardRef<NavigationPanelHandle, NavigationPanel
                 }
                 highlightedFieldPathKey={highlightedFieldPathKey}
                 wildcardIndeterminatePaths={wildcardIndeterminatePaths}
+                wildcardSelectedPaths={wildcardSelectedPaths}
               />
             ))}
           </div>

--- a/cmd/gui/frontend/src/components/ui/checkbox.tsx
+++ b/cmd/gui/frontend/src/components/ui/checkbox.tsx
@@ -1,17 +1,18 @@
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { Check } from "lucide-react"
+import { Check, Minus } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
+>(({ className, checked, ...props }, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}
+    checked={checked}
     className={cn(
-      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
       className
     )}
     {...props}
@@ -19,7 +20,11 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("grid place-content-center text-current")}
     >
-      <Check className="h-4 w-4" />
+      {checked === 'indeterminate' ? (
+        <Minus className="h-4 w-4" />
+      ) : (
+        <Check className="h-4 w-4" />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/internal/kube/node.go
+++ b/internal/kube/node.go
@@ -178,6 +178,18 @@ func CreateNodeTree(fieldTree map[string]*Field, objs []*unstructured.Unstructur
 		} else if field.IsMap() {
 			keys := getDistinctKeys(childPrefix, objs)
 			children = make(map[string]*Node)
+
+			// Add wildcard node for maps with keys (select all keys)
+			if len(keys) > 0 {
+				children["*"] = &Node{
+					field:     nil,
+					name:      "*",
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  nil, // leaf-like node for "select all siblings"
+				}
+			}
+
 			for _, key := range keys {
 				grandChildren := map[string]*Node(nil)
 				if field.Children != nil {
@@ -382,6 +394,19 @@ func UpdateNodeTree(existing map[string]*Node, fieldTree map[string]*Field, objs
 		} else if field.IsMap() {
 			keys := getDistinctKeys(childPrefix, objs)
 			children = make(map[string]*Node)
+
+			// Add wildcard node for maps with keys (select all keys)
+			if len(keys) > 0 {
+				children["*"] = &Node{
+					field:     nil,
+					name:      "*",
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  nil,
+					Expanded:  exists && existingNode.children != nil && existingNode.children["*"] != nil && existingNode.children["*"].Expanded,
+					Selected:  exists && existingNode.children != nil && existingNode.children["*"] != nil && existingNode.children["*"].Selected,
+				}
+			}
 
 			for _, mapKey := range keys {
 				var grandChildren map[string]*Node


### PR DESCRIPTION
## Summary
- Add wildcard (*) checkbox for `map[string]` type fields to select all sibling keys at once
- Provides UI consistency with existing array wildcard functionality
- Map * is a leaf-like node (no children) - shows checkbox only, no expand button

## Changes

### Backend (`internal/kube/node.go`)
- Add `*` wildcard node for Map types in `CreateNodeTree`
- Add `*` wildcard node for Map types in `UpdateNodeTree` (preserves Expanded/Selected state)

### Frontend
- `useTree.ts`: Extend `toggleSelect` to handle Map `*` at end of path (selects all sibling key leaves)
- `useTree.ts`: Add `wildcardIndeterminatePaths` computation for partial selection state
- `NavigationPanel.tsx`: Render Map `*` with checkbox and indeterminate state support

## Test plan
- [x] Backend builds successfully
- [x] Frontend type check passes
- [x] All existing tests pass (184 tests)
- [x] Manual test: Verify Map wildcard checkbox selects/deselects all sibling keys
- [x] Manual test: Verify indeterminate state shows when partially selected for Map wildcards
- [x] Manual test: Verify indeterminate state shows when partially selected for wildcards of Array under keys 

🤖 Generated with [Claude Code](https://claude.com/claude-code)