### PR TITLE
feat(search): use API shortNames for GVK search

### DIFF
--- a/cmd/gui/frontend/src/components/CommandPalette.test.tsx
+++ b/cmd/gui/frontend/src/components/CommandPalette.test.tsx
@@ -41,13 +41,15 @@ const createMockGVK = (
   kind: string,
   group: string = '',
   contexts: string[] = [],
-  allCount: number = 2
+  allCount: number = 2,
+  shortNames: string[] = []
 ): main.MultiClusterGVK => ({
   kind,
   group,
   version: 'v1',
   contexts,
   allCount,
+  shortNames,
 });
 
 // Default props for all tests
@@ -388,8 +390,8 @@ describe('CommandPalette - Resource Sorting', () => {
 
   it('should sort core resources before non-core resources', () => {
     const gvks = [
-      { kind: 'Deployment', group: 'apps', version: 'v1', contexts: ['ctx'], allCount: 1 },
-      { kind: 'Pod', group: '', version: 'v1', contexts: ['ctx'], allCount: 1 },
+      { kind: 'Deployment', group: 'apps', version: 'v1', contexts: ['ctx'], allCount: 1, shortNames: ['deploy'] },
+      { kind: 'Pod', group: '', version: 'v1', contexts: ['ctx'], allCount: 1, shortNames: ['po'] },
     ];
 
     render(
@@ -418,9 +420,9 @@ describe('CommandPalette - Resource Sorting', () => {
 
   it('should sort versions in semver order (stable > beta > alpha)', async () => {
     const gvks = [
-      { kind: 'NetworkPolicy', group: 'networking.k8s.io', version: 'v1alpha1', contexts: ['ctx'], allCount: 1 },
-      { kind: 'NetworkPolicy', group: 'networking.k8s.io', version: 'v1', contexts: ['ctx'], allCount: 1 },
-      { kind: 'NetworkPolicy', group: 'networking.k8s.io', version: 'v1beta1', contexts: ['ctx'], allCount: 1 },
+      { kind: 'NetworkPolicy', group: 'networking.k8s.io', version: 'v1alpha1', contexts: ['ctx'], allCount: 1, shortNames: ['netpol'] },
+      { kind: 'NetworkPolicy', group: 'networking.k8s.io', version: 'v1', contexts: ['ctx'], allCount: 1, shortNames: ['netpol'] },
+      { kind: 'NetworkPolicy', group: 'networking.k8s.io', version: 'v1beta1', contexts: ['ctx'], allCount: 1, shortNames: ['netpol'] },
     ];
 
     render(
@@ -460,8 +462,8 @@ describe('CommandPalette - Resource Sorting', () => {
 
   it('should sort higher major versions first', async () => {
     const gvks = [
-      { kind: 'CustomResource', group: 'example.com', version: 'v1', contexts: ['ctx'], allCount: 1 },
-      { kind: 'CustomResource', group: 'example.com', version: 'v2', contexts: ['ctx'], allCount: 1 },
+      { kind: 'CustomResource', group: 'example.com', version: 'v1', contexts: ['ctx'], allCount: 1, shortNames: [] },
+      { kind: 'CustomResource', group: 'example.com', version: 'v2', contexts: ['ctx'], allCount: 1, shortNames: [] },
     ];
 
     render(

--- a/cmd/gui/frontend/src/components/CommandPalette.tsx
+++ b/cmd/gui/frontend/src/components/CommandPalette.tsx
@@ -255,60 +255,9 @@ export function CommandPalette({ contexts, gvks, favorites, loading, theme, onCl
                 {/* RESOURCES Group */}
                 {filteredGVKs.length > 0 && (
                   <CommandGroup heading="RESOURCES">
-                {filteredGVKs.map(({ gvk, indices, abbreviation }, index) => {
+                {filteredGVKs.map(({ gvk, abbrIndices, kindIndices, groupIndices, abbreviation }, index) => {
                   const isCore = gvk.group === "";
                   const availableCount = gvk.contexts?.length || 0;
-
-                  // Calculate indices for abbr, kind, and group separately
-                  // searchText format: "abbr kind group" or "kind group" (if no abbr)
-                  let abbrIndices: readonly [number, number][] = [];
-                  let kindIndices: readonly [number, number][] = [];
-                  let groupIndices: readonly [number, number][] = [];
-
-                  if (indices && indices.length > 0) {
-                    const abbrLength = abbreviation ? abbreviation.length : 0;
-                    const kindLength = gvk.kind.length;
-                    const groupLength = gvk.group.length;
-
-                    // Calculate start positions
-                    const kindStart = abbreviation ? abbrLength + 1 : 0; // +1 for space after abbr
-                    const groupStart = abbreviation
-                      ? abbrLength + 1 + kindLength + 1 // abbr + space + kind + space
-                      : kindLength + 1; // kind + space
-
-                    const abbrRanges: [number, number][] = [];
-                    const kindRanges: [number, number][] = [];
-                    const groupRanges: [number, number][] = [];
-
-                    indices.forEach(([start, end]) => {
-                      // Check abbr region (if exists)
-                      if (abbreviation && start < abbrLength && end < kindStart) {
-                        abbrRanges.push([start, Math.min(end, abbrLength - 1)]);
-                      }
-
-                      // Check kind region
-                      if (start < groupStart && end >= kindStart) {
-                        const kindRangeStart = Math.max(start, kindStart) - kindStart;
-                        const kindRangeEnd = Math.min(end, groupStart - 2) - kindStart; // -2 for space before group
-                        if (kindRangeEnd >= kindRangeStart && kindRangeEnd < kindLength) {
-                          kindRanges.push([kindRangeStart, kindRangeEnd]);
-                        }
-                      }
-
-                      // Check group region (if exists)
-                      if (groupLength > 0 && end >= groupStart) {
-                        const groupRangeStart = Math.max(start, groupStart) - groupStart;
-                        const groupRangeEnd = end - groupStart;
-                        if (groupRangeEnd >= groupRangeStart && groupRangeEnd < groupLength) {
-                          groupRanges.push([groupRangeStart, groupRangeEnd]);
-                        }
-                      }
-                    });
-
-                    abbrIndices = abbrRanges;
-                    kindIndices = kindRanges;
-                    groupIndices = groupRanges;
-                  }
 
                   return (
                     <CommandItem
@@ -325,7 +274,7 @@ export function CommandPalette({ contexts, gvks, favorites, loading, theme, onCl
                             variant="outline"
                             className="text-xs font-mono px-1.5 py-0 h-5"
                           >
-                            {abbrIndices.length > 0 ? (
+                            {abbrIndices && abbrIndices.length > 0 ? (
                               <HighlightedText
                                 text={abbreviation}
                                 indices={abbrIndices}
@@ -337,7 +286,7 @@ export function CommandPalette({ contexts, gvks, favorites, loading, theme, onCl
                         )}
 
                         <span className={abbreviation ? "" : "ml-2"}>
-                          {kindIndices.length > 0 ? (
+                          {kindIndices && kindIndices.length > 0 ? (
                             <HighlightedText
                               text={gvk.kind}
                               indices={kindIndices}
@@ -354,7 +303,7 @@ export function CommandPalette({ contexts, gvks, favorites, loading, theme, onCl
                         >
                           {isCore ? (
                             gvk.version
-                          ) : groupIndices.length > 0 ? (
+                          ) : groupIndices && groupIndices.length > 0 ? (
                             <>
                               <HighlightedText
                                 text={gvk.group}

--- a/cmd/gui/frontend/src/components/CommandPalette.tsx
+++ b/cmd/gui/frontend/src/components/CommandPalette.tsx
@@ -255,52 +255,59 @@ export function CommandPalette({ contexts, gvks, favorites, loading, theme, onCl
                 {/* RESOURCES Group */}
                 {filteredGVKs.length > 0 && (
                   <CommandGroup heading="RESOURCES">
-                {filteredGVKs.map(({ gvk, indices }, index) => {
+                {filteredGVKs.map(({ gvk, indices, abbreviation }, index) => {
                   const isCore = gvk.group === "";
                   const availableCount = gvk.contexts?.length || 0;
 
-                  // Calculate indices for group and kind separately
-                  // indices is in range format: [number, number][]
-                  let groupIndices: readonly [number, number][] = [];
+                  // Calculate indices for abbr, kind, and group separately
+                  // searchText format: "abbr kind group" or "kind group" (if no abbr)
+                  let abbrIndices: readonly [number, number][] = [];
                   let kindIndices: readonly [number, number][] = [];
+                  let groupIndices: readonly [number, number][] = [];
 
                   if (indices && indices.length > 0) {
-                    if (gvk.group) {
-                      // searchableText is "group kind" format (e.g., "apps Deployment")
-                      const groupLength = gvk.group.length;
-                      const kindStart = groupLength + 1; // +1 for space
+                    const abbrLength = abbreviation ? abbreviation.length : 0;
+                    const kindLength = gvk.kind.length;
+                    const groupLength = gvk.group.length;
 
-                      // Process each range
-                      const groupRanges: [number, number][] = [];
-                      const kindRanges: [number, number][] = [];
+                    // Calculate start positions
+                    const kindStart = abbreviation ? abbrLength + 1 : 0; // +1 for space after abbr
+                    const groupStart = abbreviation
+                      ? abbrLength + 1 + kindLength + 1 // abbr + space + kind + space
+                      : kindLength + 1; // kind + space
 
-                      indices.forEach(([start, end]) => {
-                        // Check if range overlaps with group (0 to groupLength-1)
-                        if (end < groupLength) {
-                          groupRanges.push([start, end]);
-                        }
-                        // Check if range overlaps with kind (kindStart onwards)
-                        else if (start >= kindStart) {
-                          // Adjust to be relative to kind start
-                          kindRanges.push([start - kindStart, end - kindStart]);
-                        }
-                        // Range spans across group and kind (rare but possible)
-                        else {
-                          if (start < groupLength) {
-                            groupRanges.push([start, groupLength - 1]);
-                          }
-                          if (end >= kindStart) {
-                            kindRanges.push([0, end - kindStart]);
-                          }
-                        }
-                      });
+                    const abbrRanges: [number, number][] = [];
+                    const kindRanges: [number, number][] = [];
+                    const groupRanges: [number, number][] = [];
 
-                      groupIndices = groupRanges;
-                      kindIndices = kindRanges;
-                    } else {
-                      // Core resources: searchableText is just "kind"
-                      kindIndices = indices;
-                    }
+                    indices.forEach(([start, end]) => {
+                      // Check abbr region (if exists)
+                      if (abbreviation && start < abbrLength && end < kindStart) {
+                        abbrRanges.push([start, Math.min(end, abbrLength - 1)]);
+                      }
+
+                      // Check kind region
+                      if (start < groupStart && end >= kindStart) {
+                        const kindRangeStart = Math.max(start, kindStart) - kindStart;
+                        const kindRangeEnd = Math.min(end, groupStart - 2) - kindStart; // -2 for space before group
+                        if (kindRangeEnd >= kindRangeStart && kindRangeEnd < kindLength) {
+                          kindRanges.push([kindRangeStart, kindRangeEnd]);
+                        }
+                      }
+
+                      // Check group region (if exists)
+                      if (groupLength > 0 && end >= groupStart) {
+                        const groupRangeStart = Math.max(start, groupStart) - groupStart;
+                        const groupRangeEnd = end - groupStart;
+                        if (groupRangeEnd >= groupRangeStart && groupRangeEnd < groupLength) {
+                          groupRanges.push([groupRangeStart, groupRangeEnd]);
+                        }
+                      }
+                    });
+
+                    abbrIndices = abbrRanges;
+                    kindIndices = kindRanges;
+                    groupIndices = groupRanges;
                   }
 
                   return (
@@ -310,9 +317,26 @@ export function CommandPalette({ contexts, gvks, favorites, loading, theme, onCl
                       onSelect={() => handleSelect(gvk)}
                       className="flex items-center justify-between py-2"
                     >
-                      {/* Left side: Kind name and Group badge */}
+                      {/* Left side: Abbreviation badge, Kind name, and Group badge */}
                       <div className="flex items-center gap-2">
-                        <span className="ml-2">
+                        {/* Abbreviation badge */}
+                        {abbreviation && (
+                          <Badge
+                            variant="outline"
+                            className="text-xs font-mono px-1.5 py-0 h-5"
+                          >
+                            {abbrIndices.length > 0 ? (
+                              <HighlightedText
+                                text={abbreviation}
+                                indices={abbrIndices}
+                              />
+                            ) : (
+                              abbreviation
+                            )}
+                          </Badge>
+                        )}
+
+                        <span className={abbreviation ? "" : "ml-2"}>
                           {kindIndices.length > 0 ? (
                             <HighlightedText
                               text={gvk.kind}

--- a/cmd/gui/frontend/src/components/DIYTable.test.tsx
+++ b/cmd/gui/frontend/src/components/DIYTable.test.tsx
@@ -63,6 +63,7 @@ const defaultGVK = {
   kind: 'Pod',
   contexts: ['ctx1'],
   allCount: 1,
+  shortNames: ['po'],
 };
 
 const defaultProps = {

--- a/cmd/gui/frontend/src/components/DynamicFieldTree.test.tsx
+++ b/cmd/gui/frontend/src/components/DynamicFieldTree.test.tsx
@@ -26,6 +26,7 @@ const createMockGVK = (
   version,
   contexts: ['test-context'],
   allCount: 1,
+  shortNames: [],
 });
 
 describe('DynamicFieldTree', () => {

--- a/cmd/gui/frontend/src/hooks/useCommandSearch.test.ts
+++ b/cmd/gui/frontend/src/hooks/useCommandSearch.test.ts
@@ -37,7 +37,9 @@ const createMockFavorite = (
   name,
   gvk: { kind, group, version: 'v1' },
   fields: [],
-});
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+} as unknown as main.FavoriteViewResponse);
 
 describe('useCommandSearch', () => {
   describe('GVK search scoring', () => {

--- a/cmd/gui/frontend/src/hooks/useCommandSearch.test.ts
+++ b/cmd/gui/frontend/src/hooks/useCommandSearch.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for useCommandSearch hook
+ *
+ * These tests document the custom scoring algorithm for GVK search.
+ * See useCommandSearch.ts for detailed documentation of the scoring strategy.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCommandSearch } from './useCommandSearch';
+import { main } from '../../wailsjs/go/models';
+
+// Helper to create mock GVK
+const createMockGVK = (
+  kind: string,
+  group: string = '',
+  version: string = 'v1',
+  shortNames: string[] = [],
+  contexts: string[] = ['ctx1']
+): main.MultiClusterGVK => ({
+  kind,
+  group,
+  version,
+  shortNames,
+  contexts,
+  allCount: contexts.length,
+});
+
+// Helper to create mock favorite
+const createMockFavorite = (
+  id: string,
+  name: string,
+  kind: string,
+  group: string = ''
+): main.FavoriteViewResponse => ({
+  id,
+  name,
+  gvk: { kind, group, version: 'v1' },
+  fields: [],
+});
+
+describe('useCommandSearch', () => {
+  describe('GVK search scoring', () => {
+    it('should prioritize exact abbreviation match over fuzzy matches', () => {
+      const gvks = [
+        createMockGVK('ClusterWorkflowTemplate', 'argoproj.io', 'v1alpha1', ['cwft']),
+        createMockGVK('Certificate', 'cert-manager.io', 'v1', ['cert']),
+        createMockGVK('ClusterIssuer', 'cert-manager.io', 'v1', ['clusterissuer']),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      act(() => {
+        result.current.setQuery('cert');
+      });
+
+      // Certificate (abbr=cert) should be first due to exact match
+      expect(result.current.filteredGVKs[0].gvk.kind).toBe('Certificate');
+    });
+
+    it('should prioritize abbreviation prefix match over kind prefix match', () => {
+      const gvks = [
+        createMockGVK('Deployment', 'apps', 'v1', ['deploy']),
+        createMockGVK('DaemonSet', 'apps', 'v1', ['ds']),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      act(() => {
+        result.current.setQuery('de');
+      });
+
+      // Deployment (abbr starts with "de") should be first
+      expect(result.current.filteredGVKs[0].gvk.kind).toBe('Deployment');
+    });
+
+    it('should prioritize kind prefix match over fuzzy matches', () => {
+      const gvks = [
+        createMockGVK('Pod', '', 'v1', ['po']),
+        createMockGVK('HorizontalPodAutoscaler', 'autoscaling', 'v2', ['hpa']),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      act(() => {
+        result.current.setQuery('pod');
+      });
+
+      // Pod (kind starts with "pod") should be first
+      expect(result.current.filteredGVKs[0].gvk.kind).toBe('Pod');
+    });
+
+    it('should deprioritize group-only matches', () => {
+      const gvks = [
+        createMockGVK('Certificate', 'cert-manager.io', 'v1', ['cert']),
+        createMockGVK('Issuer', 'cert-manager.io', 'v1', []),
+        createMockGVK('ClusterIssuer', 'cert-manager.io', 'v1', []),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      act(() => {
+        result.current.setQuery('cert');
+      });
+
+      // Certificate should be first (exact abbr match)
+      // Issuer and ClusterIssuer only match on group, should be lower
+      expect(result.current.filteredGVKs[0].gvk.kind).toBe('Certificate');
+    });
+  });
+
+  describe('empty abbreviation handling', () => {
+    it('should not boost GVKs without shortNames on empty string match', () => {
+      const gvks = [
+        createMockGVK('Pod', '', 'v1', ['po']),           // has shortName
+        createMockGVK('ConfigMap', '', 'v1', ['cm']),     // has shortName
+        createMockGVK('Namespace', '', 'v1', []),         // no shortName
+        createMockGVK('Node', '', 'v1', []),              // no shortName
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      act(() => {
+        result.current.setQuery('po');
+      });
+
+      // Pod should match (abbr="po" exact match)
+      // Namespace and Node should NOT appear at top just because abbr is empty
+      const kinds = result.current.filteredGVKs.map(r => r.gvk.kind);
+      expect(kinds[0]).toBe('Pod');
+
+      // Namespace and Node should only match if "po" fuzzy-matches their kind
+      // which it doesn't for exact/prefix, so they should be lower or not present
+    });
+
+    it('should still match GVKs without shortNames by kind', () => {
+      const gvks = [
+        createMockGVK('Namespace', '', 'v1', []),  // no shortName
+        createMockGVK('Pod', '', 'v1', ['po']),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      act(() => {
+        result.current.setQuery('name');
+      });
+
+      // Namespace should match via kind prefix
+      const kinds = result.current.filteredGVKs.map(r => r.gvk.kind);
+      expect(kinds).toContain('Namespace');
+    });
+
+    it('should not treat empty abbreviation as matching any query', () => {
+      const gvks = [
+        createMockGVK('Secret', '', 'v1', []),  // no shortName (abbr='')
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      act(() => {
+        result.current.setQuery('xyz');
+      });
+
+      // 'xyz' should not match Secret at all
+      // Secret has no abbr, kind doesn't match, group doesn't match
+      expect(result.current.filteredGVKs.length).toBe(0);
+    });
+  });
+
+  describe('favorites search', () => {
+    it('should filter favorites by query', () => {
+      const favorites = [
+        createMockFavorite('1', 'my-deployment', 'Deployment', 'apps'),
+        createMockFavorite('2', 'my-service', 'Service'),
+        createMockFavorite('3', 'nginx-pod', 'Pod'),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch(favorites, []));
+
+      act(() => {
+        result.current.setQuery('deploy');
+      });
+
+      expect(result.current.filteredFavorites.length).toBe(1);
+      expect(result.current.filteredFavorites[0].favorite.name).toBe('my-deployment');
+    });
+
+    it('should return all favorites when query is empty', () => {
+      const favorites = [
+        createMockFavorite('1', 'my-deployment', 'Deployment', 'apps'),
+        createMockFavorite('2', 'my-service', 'Service'),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch(favorites, []));
+
+      expect(result.current.filteredFavorites.length).toBe(2);
+    });
+
+    it('should include highlight indices for matched favorites', () => {
+      const favorites = [
+        createMockFavorite('1', 'my-deployment', 'Deployment', 'apps'),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch(favorites, []));
+
+      act(() => {
+        result.current.setQuery('deploy');
+      });
+
+      expect(result.current.filteredFavorites[0].indices).not.toBeNull();
+      expect(result.current.filteredFavorites[0].indices!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('sorting', () => {
+    it('should sort core resources before non-core when scores are equal', () => {
+      const gvks = [
+        createMockGVK('Deployment', 'apps', 'v1', []),
+        createMockGVK('Pod', '', 'v1', []),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      // No query - all have same score (0)
+      const kinds = result.current.filteredGVKs.map(r => r.gvk.kind);
+      expect(kinds.indexOf('Pod')).toBeLessThan(kinds.indexOf('Deployment'));
+    });
+
+    it('should sort by version (semver descending) for same kind', () => {
+      const gvks = [
+        createMockGVK('NetworkPolicy', 'networking.k8s.io', 'v1alpha1', []),
+        createMockGVK('NetworkPolicy', 'networking.k8s.io', 'v1', []),
+        createMockGVK('NetworkPolicy', 'networking.k8s.io', 'v1beta1', []),
+      ];
+
+      const { result } = renderHook(() => useCommandSearch([], gvks));
+
+      const versions = result.current.filteredGVKs.map(r => r.gvk.version);
+      expect(versions).toEqual(['v1', 'v1beta1', 'v1alpha1']);
+    });
+  });
+});

--- a/cmd/gui/frontend/src/hooks/useCommandSearch.ts
+++ b/cmd/gui/frontend/src/hooks/useCommandSearch.ts
@@ -309,7 +309,7 @@ export function useCommandSearch(
 
     // Sort by score (desc) -> group (core first) -> kind -> version
     results.sort((a, b) => {
-      // 1. Score first (closer to 0 is better)
+      // 1. Score first (higher is better)
       if (a.score !== b.score) {
         return b.score - a.score;
       }

--- a/cmd/gui/frontend/src/hooks/useCommandSearch.ts
+++ b/cmd/gui/frontend/src/hooks/useCommandSearch.ts
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import fuzzysort from "fuzzysort";
 import { main } from "../../wailsjs/go/models";
-import { useFuzzySearch } from "./useFuzzySearch";
+import { useFuzzySearch, indexesToRanges } from "./useFuzzySearch";
 import { compareVersions } from "@/lib/version";
 
 /**
@@ -11,23 +12,30 @@ function getFirstShortName(shortNames: string[] | undefined): string | undefined
   return shortNames && shortNames.length > 0 ? shortNames[0] : undefined;
 }
 
-/**
- * Internal search item type for unified fuzzy search.
- * This union allows searching across both favorites and GVKs with a single query.
- */
-type SearchItem =
-  | { type: 'favorite'; favorite: main.FavoriteViewResponse; searchText: string }
-  | { type: 'gvk'; gvk: main.MultiClusterGVK; searchText: string };
-
 export interface FavoriteSearchResult {
   favorite: main.FavoriteViewResponse;
   indices: readonly [number, number][] | null;
 }
 
+/**
+ * GVK search result with field-specific highlight indices.
+ *
+ * The search uses multi-key fuzzy matching with field boosting:
+ * - abbreviation: Highest priority (exact match gets maximum score)
+ * - kind: Medium priority
+ * - group: Lowest priority (to prevent group matches from overshadowing abbr matches)
+ */
 export interface GVKSearchResult {
   gvk: main.MultiClusterGVK;
-  indices: readonly [number, number][] | null;
+  /** Highlight indices for abbreviation field */
+  abbrIndices: readonly [number, number][] | null;
+  /** Highlight indices for kind field */
+  kindIndices: readonly [number, number][] | null;
+  /** Highlight indices for group field */
+  groupIndices: readonly [number, number][] | null;
+  /** First short name (abbreviation) for display */
   abbreviation: string | undefined;
+  /** Combined search score (closer to 0 is better) */
   score: number;
 }
 
@@ -39,68 +47,260 @@ interface UseCommandSearchResult {
 }
 
 /**
+ * Prepared GVK item for fuzzysort multi-key search.
+ * Pre-computing search fields improves performance.
+ */
+interface PreparedGVKItem {
+  gvk: main.MultiClusterGVK;
+  abbr: string;
+  kind: string;
+  group: string;
+}
+
+/**
+ * Score bonuses and penalties for different match types.
+ * Higher score = better (closer to 0 or positive).
+ *
+ * Scoring Strategy (Priority Order):
+ * 1. Abbreviation exact match: +1000 (best)
+ * 2. Abbreviation prefix match: +500
+ * 3. Kind prefix match: +100
+ * 4. Abbreviation fuzzy match: raw score
+ * 5. Kind fuzzy match: -1000 penalty
+ * 6. Group match: -5000 penalty (lowest priority)
+ *
+ * This ensures "cert" → Certificate (abbr=cert) ranks first,
+ * not ClusterWorkflowTemplate (abbr contains c...e...r...t fuzzy).
+ */
+const SCORE_ADJUSTMENTS = {
+  ABBR_EXACT: 1000,      // abbr === query
+  ABBR_PREFIX: 500,      // abbr.startsWith(query)
+  KIND_PREFIX: 100,      // kind.startsWith(query)
+  ABBR_FUZZY: 0,         // fuzzy match on abbr
+  KIND_FUZZY: -1000,     // fuzzy match on kind
+  GROUP_FUZZY: -5000,    // fuzzy match on group
+} as const;
+
+/**
+ * Calculate combined score from multi-key search results with field boosting.
+ *
+ * Prioritizes exact/prefix matches over fuzzy matches to ensure
+ * abbreviation searches like "po" return Pod first, not random fuzzy matches.
+ *
+ * @param abbrResult - Fuzzysort result for abbreviation field
+ * @param kindResult - Fuzzysort result for kind field
+ * @param groupResult - Fuzzysort result for group field
+ * @param query - Original search query
+ * @param abbr - Original abbreviation value
+ * @param kind - Original kind value
+ * @returns Combined score where higher is better
+ */
+function calculateBoostedScore(
+  abbrResult: Fuzzysort.Result | null,
+  kindResult: Fuzzysort.Result | null,
+  groupResult: Fuzzysort.Result | null,
+  query: string,
+  abbr: string,
+  kind: string
+): number {
+  const queryLower = query.toLowerCase();
+  const abbrLower = abbr.toLowerCase();
+  const kindLower = kind.toLowerCase();
+
+  // Priority 1: Exact abbreviation match (e.g., "cert" === "cert")
+  if (abbrLower && abbrLower === queryLower) {
+    return SCORE_ADJUSTMENTS.ABBR_EXACT;
+  }
+
+  // Priority 2: Abbreviation prefix match (e.g., "po" matches "pod" abbreviation if it existed)
+  if (abbrLower && abbrLower.startsWith(queryLower)) {
+    return SCORE_ADJUSTMENTS.ABBR_PREFIX;
+  }
+
+  // Priority 3: Kind prefix match (e.g., "Pod" starts with "po")
+  if (kindLower.startsWith(queryLower)) {
+    return SCORE_ADJUSTMENTS.KIND_PREFIX;
+  }
+
+  // Priority 4-6: Fuzzy matches with penalties
+  const scores: number[] = [];
+
+  if (abbrResult) {
+    scores.push(abbrResult.score + SCORE_ADJUSTMENTS.ABBR_FUZZY);
+  }
+  if (kindResult) {
+    scores.push(kindResult.score + SCORE_ADJUSTMENTS.KIND_FUZZY);
+  }
+  if (groupResult) {
+    scores.push(groupResult.score + SCORE_ADJUSTMENTS.GROUP_FUZZY);
+  }
+
+  // Return best score, or -Infinity if no matches
+  return scores.length > 0 ? Math.max(...scores) : -Infinity;
+}
+
+/**
  * Custom hook for CommandPalette search functionality.
- * Provides unified fuzzy search across favorites and GVKs,
- * with results separated and sorted appropriately.
+ *
+ * ## Search Strategy
+ *
+ * ### Favorites
+ * Uses single-key fuzzy search on combined text (name + GVK info).
+ *
+ * ### GVKs (Kubernetes Resources)
+ * Uses multi-key fuzzy search with prioritized matching:
+ *
+ * | Priority | Match Type | Score Bonus | Example |
+ * |----------|------------|-------------|---------|
+ * | 1 | Abbr exact | +1000 | "cert" === "cert" (Certificate) |
+ * | 2 | Abbr prefix | +500 | "de" starts "deploy" |
+ * | 3 | Kind prefix | +100 | "Pod" starts with "po" |
+ * | 4 | Abbr fuzzy | 0 | fuzzy match on abbreviation |
+ * | 5 | Kind fuzzy | -1000 | fuzzy match on kind |
+ * | 6 | Group fuzzy | -5000 | fuzzy match on group |
+ *
+ * This ensures exact/prefix matches rank above fuzzy matches,
+ * so "po" → Pod, "cert" → Certificate (not fuzzy matches in other fields).
+ *
+ * ## Sorting
+ * Results are sorted by:
+ * 1. Score (higher is better)
+ * 2. Core group first (empty string)
+ * 3. Group alphabetically
+ * 4. Kind alphabetically
+ * 5. Version (semver descending)
  */
 export function useCommandSearch(
   favorites: main.FavoriteViewResponse[],
   gvks: main.MultiClusterGVK[]
 ): UseCommandSearchResult {
-  // Build searchable items from favorites and GVKs
-  const searchItems = useMemo((): SearchItem[] => {
-    const favItems: SearchItem[] = favorites.map((fav) => {
+  const [query, setQuery] = useState('');
+
+  // Prepare favorite items for search
+  const favoriteItems = useMemo(() => {
+    return favorites.map((fav) => {
       const gvkText = fav.gvk.group ? `${fav.gvk.group} ${fav.gvk.kind}` : fav.gvk.kind;
       return {
-        type: 'favorite' as const,
         favorite: fav,
         searchText: `${fav.name} ${gvkText}`,
       };
     });
+  }, [favorites]);
 
-    const gvkItems: SearchItem[] = gvks.map((gvk) => {
-      const abbr = getFirstShortName(gvk.shortNames);
-      // Include abbreviation at the beginning for priority matching
-      // Format: "abbr kind group" or "kind group" if no abbreviation
-      const searchText = abbr
-        ? `${abbr} ${gvk.kind} ${gvk.group}`.trim()
-        : `${gvk.kind} ${gvk.group}`.trim();
-      return {
-        type: 'gvk' as const,
-        gvk,
-        searchText,
-      };
+  // Prepare GVK items for multi-key search
+  const preparedGVKs = useMemo((): PreparedGVKItem[] => {
+    return gvks.map((gvk) => ({
+      gvk,
+      abbr: getFirstShortName(gvk.shortNames) ?? '',
+      kind: gvk.kind,
+      group: gvk.group,
+    }));
+  }, [gvks]);
+
+  // Search favorites using existing fuzzy search
+  const { results: favoriteResults } = useFuzzySearch(
+    favoriteItems,
+    (item) => item.searchText
+  );
+
+  // Filter favorites based on query
+  const filteredFavorites = useMemo((): FavoriteSearchResult[] => {
+    if (!query) {
+      // No query: return all favorites
+      return favorites.map((fav) => ({
+        favorite: fav,
+        indices: null,
+      }));
+    }
+
+    return favoriteResults
+      .filter((result) => result.item.favorite)
+      .map((result) => ({
+        favorite: result.item.favorite,
+        indices: result.indices.length > 0 ? result.indices : null,
+      }));
+  }, [query, favorites, favoriteResults]);
+
+  // Search GVKs using multi-key fuzzysort with field boosting
+  const filteredGVKs = useMemo((): GVKSearchResult[] => {
+    if (!query) {
+      // No query: return all GVKs sorted by group/kind/version
+      return preparedGVKs
+        .map((item) => ({
+          gvk: item.gvk,
+          abbrIndices: null,
+          kindIndices: null,
+          groupIndices: null,
+          abbreviation: item.abbr || undefined,
+          score: 0,
+        }))
+        .sort((a, b) => {
+          // Core group first
+          const aIsCore = a.gvk.group === "";
+          const bIsCore = b.gvk.group === "";
+          if (aIsCore && !bIsCore) return -1;
+          if (!aIsCore && bIsCore) return 1;
+
+          // Group alphabetically
+          if (a.gvk.group !== b.gvk.group) {
+            return a.gvk.group.localeCompare(b.gvk.group);
+          }
+
+          // Kind alphabetically
+          if (a.gvk.kind !== b.gvk.kind) {
+            return a.gvk.kind.localeCompare(b.gvk.kind);
+          }
+
+          // Version (semver descending)
+          return compareVersions(a.gvk.version, b.gvk.version);
+        });
+    }
+
+    // Perform multi-key search on each field separately
+    const abbrResults = fuzzysort.go(query, preparedGVKs, { key: 'abbr', threshold: -10000 });
+    const kindResults = fuzzysort.go(query, preparedGVKs, { key: 'kind', threshold: -10000 });
+    const groupResults = fuzzysort.go(query, preparedGVKs, { key: 'group', threshold: -10000 });
+
+    // Create lookup maps for results
+    const abbrMap = new Map(abbrResults.map((r) => [r.obj, r]));
+    const kindMap = new Map(kindResults.map((r) => [r.obj, r]));
+    const groupMap = new Map(groupResults.map((r) => [r.obj, r]));
+
+    // Find all GVKs that matched in any field
+    const matchedItems = new Set<PreparedGVKItem>();
+    abbrResults.forEach((r) => matchedItems.add(r.obj));
+    kindResults.forEach((r) => matchedItems.add(r.obj));
+    groupResults.forEach((r) => matchedItems.add(r.obj));
+
+    // Build results with boosted scores
+    const results: GVKSearchResult[] = [];
+    matchedItems.forEach((item) => {
+      const abbrResult = abbrMap.get(item) ?? null;
+      const kindResult = kindMap.get(item) ?? null;
+      const groupResult = groupMap.get(item) ?? null;
+
+      const score = calculateBoostedScore(
+        abbrResult,
+        kindResult,
+        groupResult,
+        query,
+        item.abbr,
+        item.kind
+      );
+
+      results.push({
+        gvk: item.gvk,
+        abbrIndices: abbrResult ? indexesToRanges(abbrResult.indexes) : null,
+        kindIndices: kindResult ? indexesToRanges(kindResult.indexes) : null,
+        groupIndices: groupResult ? indexesToRanges(groupResult.indexes) : null,
+        abbreviation: item.abbr || undefined,
+        score,
+      });
     });
 
-    return [...favItems, ...gvkItems];
-  }, [favorites, gvks]);
-
-  const { query, setQuery, results } = useFuzzySearch(searchItems, (item) => item.searchText);
-
-  // Separate and sort results
-  const { filteredFavorites, filteredGVKs } = useMemo(() => {
-    const favoriteResults: FavoriteSearchResult[] = [];
-    const gvkResults: GVKSearchResult[] = [];
-
-    results.forEach((result) => {
-      if (result.item.type === 'favorite') {
-        favoriteResults.push({
-          favorite: result.item.favorite,
-          indices: result.indices.length > 0 ? result.indices : null,
-        });
-      } else {
-        gvkResults.push({
-          gvk: result.item.gvk,
-          indices: result.indices.length > 0 ? result.indices : null,
-          abbreviation: getFirstShortName(result.item.gvk.shortNames),
-          score: result.score,
-        });
-      }
-    });
-
-    // Sort GVKs: score (desc) -> group (core first) -> kind -> version (semver desc)
-    gvkResults.sort((a, b) => {
-      // 1. Score first (higher is better, fuzzysort returns negative scores where closer to 0 is better)
+    // Sort by score (desc) -> group (core first) -> kind -> version
+    results.sort((a, b) => {
+      // 1. Score first (closer to 0 is better)
       if (a.score !== b.score) {
         return b.score - a.score;
       }
@@ -108,7 +308,6 @@ export function useCommandSearch(
       // 2. Core group (empty string) comes first
       const aIsCore = a.gvk.group === "";
       const bIsCore = b.gvk.group === "";
-
       if (aIsCore && !bIsCore) return -1;
       if (!aIsCore && bIsCore) return 1;
 
@@ -126,8 +325,8 @@ export function useCommandSearch(
       return compareVersions(a.gvk.version, b.gvk.version);
     });
 
-    return { filteredFavorites: favoriteResults, filteredGVKs: gvkResults };
-  }, [results]);
+    return results;
+  }, [query, preparedGVKs]);
 
   return { query, setQuery, filteredFavorites, filteredGVKs };
 }

--- a/cmd/gui/frontend/wailsjs/go/models.ts
+++ b/cmd/gui/frontend/wailsjs/go/models.ts
@@ -76,6 +76,7 @@ export namespace main {
 	    group: string;
 	    version: string;
 	    kind: string;
+	    shortNames: string[];
 	    contexts: string[];
 	    allCount: number;
 	
@@ -88,6 +89,7 @@ export namespace main {
 	        this.group = source["group"];
 	        this.version = source["version"];
 	        this.kind = source["kind"];
+	        this.shortNames = source["shortNames"];
 	        this.contexts = source["contexts"];
 	        this.allCount = source["allCount"];
 	    }


### PR DESCRIPTION
## Summary
- Fetch shortNames from Kubernetes Discovery API instead of hardcoding
- Support abbreviations for both built-in resources and CRDs
- Add score-based sorting to prioritize better matches in search results

## Changes
- **Backend**: Add `GVKInfo` type and `GetGVKInfosForContext()` to fetch shortNames from API
- **Backend**: Add `ShortNames` field to `MultiClusterGVK` struct
- **Frontend**: Use backend shortNames for search text and abbreviation badge display
- **Frontend**: Remove hardcoded `GVK_ABBREVIATIONS` from constants.ts

## Manual Testing Checklist
- [x] Open Command Palette (Cmd+K)
- [x] Search for built-in resource by abbreviation (e.g., `po` for Pod, `deploy` for Deployment, `svc` for Service)
- [x] Verify abbreviation badge is displayed next to the resource kind
- [x] Search for CRD by abbreviation (e.g., `gss` for GameServerSet if Agones is installed)
- [x] Verify CRD abbreviation badge is displayed correctly
- [x] Verify search results are sorted by match score (better matches first)
- [x] Verify core resources (empty group) still appear before non-core resources when scores are equal
- [x] Select a resource and verify it loads correctly

🤖 Generated with [Claude Code](https://claude.ai/code)