### PR TITLE
fix(test): remove type assertion violating CODE_QUALITY.md

### DIFF
--- a/cmd/gui/frontend/src/hooks/useCommandSearch.test.ts
+++ b/cmd/gui/frontend/src/hooks/useCommandSearch.test.ts
@@ -26,20 +26,21 @@ const createMockGVK = (
   allCount: contexts.length,
 });
 
-// Helper to create mock favorite
+// Helper to create mock favorite using the class constructor
 const createMockFavorite = (
   id: string,
   name: string,
   kind: string,
   group: string = ''
-): main.FavoriteViewResponse => ({
-  id,
-  name,
-  gvk: { kind, group, version: 'v1' },
-  fields: [],
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-01-01T00:00:00Z',
-} as unknown as main.FavoriteViewResponse);
+): main.FavoriteViewResponse =>
+  main.FavoriteViewResponse.createFrom({
+    id,
+    name,
+    gvk: { kind, group, version: 'v1' },
+    fields: [],
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  });
 
 describe('useCommandSearch', () => {
   describe('GVK search scoring', () => {

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
+}


### PR DESCRIPTION
## Summary
- Replace `as unknown as main.FavoriteViewResponse` with proper `main.FavoriteViewResponse.createFrom()` constructor call
- Adheres to the "No type assertions (`as`)" rule in CODE_QUALITY.md

## Changes
```diff
-}: main.FavoriteViewResponse => ({
-  id,
-  name,
-  gvk: { kind, group, version: 'v1' },
-  fields: [],
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-01-01T00:00:00Z',
-} as unknown as main.FavoriteViewResponse);
+): main.FavoriteViewResponse =>
+  main.FavoriteViewResponse.createFrom({
+    id,
+    name,
+    gvk: { kind, group, version: 'v1' },
+    fields: [],
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  });
```

## Test plan
- [x] Type check passes: `tsc --noEmit`
- [x] Tests pass: `npm run test:run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)