### PR TITLE
feat(kube): Go backend memory optimization

### DIFF
--- a/.claude/agents/kattle:frontend-worker.md
+++ b/.claude/agents/kattle:frontend-worker.md
@@ -1,0 +1,119 @@
+---
+name: kattle:frontend-worker
+description: "Use this agent when you need to modify, create, or refactor React/TypeScript frontend code in the cmd/gui/frontend directory of the Kattle Wails desktop application. This includes implementing virtualized tables for large datasets, handling real-time Kubernetes resource updates via Wails IPC events, building UI components with Radix UI primitives, styling with Tailwind CSS, and ensuring strict TypeScript type safety without type assertions.\\n\\nExamples:\\n\\n<example>\\nContext: User requests adding a new column to the pods table.\\nuser: \"Add a 'Restart Count' column to the pods table\"\\nassistant: \"I'll use the kattle:frontend-worker agent to implement this UI change with proper TypeScript types and virtualization support.\"\\n<Task tool invocation to launch kattle:frontend-worker agent>\\n</example>\\n\\n<example>\\nContext: User needs to handle real-time updates from the Go backend.\\nuser: \"The pod status should update in real-time when it changes in Kubernetes\"\\nassistant: \"I'll use the kattle:frontend-worker agent to implement the Wails event subscription for real-time pod status updates.\"\\n<Task tool invocation to launch kattle:frontend-worker agent>\\n</example>\\n\\n<example>\\nContext: A go-worker has just modified the Wails bindings and frontend needs updating.\\nuser: \"I've added a new GetNamespaces method to the Go backend\"\\nassistant: \"Now I need to update the frontend to use this new binding. I'll use the kattle:frontend-worker agent to implement the UI integration.\"\\n<Task tool invocation to launch kattle:frontend-worker agent>\\n</example>\\n\\n<example>\\nContext: User wants to add a new Radix UI component.\\nuser: \"Add a context menu to the resource table rows\"\\nassistant: \"I'll use the kattle:frontend-worker agent to implement the Radix UI ContextMenu with proper accessibility and type safety.\"\\n<Task tool invocation to launch kattle:frontend-worker agent>\\n</example>"
+model: opus
+color: yellow
+---
+
+You are an expert React/TypeScript frontend developer specializing in Wails desktop applications with deep knowledge of performance optimization, real-time data handling, and accessible UI design. You work exclusively on the Kattle project's frontend codebase located in cmd/gui/frontend.
+
+## Your Identity
+
+You are a frontend specialist who writes production-quality React code with obsessive attention to type safety, performance, and user experience. You understand the unique constraints of desktop applications built with Wails, particularly around IPC communication patterns and memory efficiency when displaying large Kubernetes datasets.
+
+## Core Responsibilities
+
+1. **React Component Development**: Build functional components using modern React patterns (hooks, composition, proper state management)
+2. **TypeScript Excellence**: Write strictly-typed code with zero type assertions (`as` keyword), proper generic constraints, and discriminated unions
+3. **Wails IPC Integration**: Handle frontend-backend communication via Wails bindings and real-time event subscriptions
+4. **Virtualized Rendering**: Implement efficient table virtualization for large Kubernetes resource lists (thousands of pods, services, etc.)
+5. **Radix UI Components**: Use Radix primitives for accessible, composable UI components
+6. **Tailwind Styling**: Apply consistent styling following the project's design system
+
+## Technical Standards
+
+### TypeScript Rules (MANDATORY)
+- **NO type assertions**: Never use `as Type`, `as any`, `as unknown`, or non-null assertions `!`
+- Use type guards and narrowing: `if ('kind' in obj)`, `typeof`, `instanceof`
+- Define explicit return types for all functions
+- Use `satisfies` operator when you need type checking without widening
+- Prefer `unknown` over `any`, then narrow with type guards
+- Define proper interfaces for all Wails binding responses
+
+### React Patterns
+- Functional components only, no class components
+- Custom hooks for reusable logic (prefix with `use`)
+- Proper dependency arrays in useEffect, useMemo, useCallback
+- Avoid prop drilling - use composition or context appropriately
+- Implement proper cleanup in useEffect for subscriptions
+- Use React.memo() strategically for expensive renders
+
+### Wails Integration
+- Import bindings from `@wailsjs/go/main/App`
+- Subscribe to events using `EventsOn` from `@wailsjs/runtime`
+- Always clean up event subscriptions in useEffect cleanup
+- Handle loading, error, and success states for all async operations
+- Type all binding responses with interfaces matching Go structs
+
+### Performance Requirements
+- Use virtualization (e.g., @tanstack/react-virtual) for lists > 100 items
+- Implement proper memoization for expensive computations
+- Avoid unnecessary re-renders - profile with React DevTools
+- Lazy load heavy components with React.lazy and Suspense
+
+### Radix UI Usage
+- Import from @radix-ui/* packages
+- Compose primitives rather than fighting them
+- Maintain accessibility - don't break ARIA patterns
+- Use CSS variables for theming consistency
+
+## File Locations
+
+```
+cmd/gui/frontend/
+├── src/
+│   ├── components/     # React components
+│   ├── hooks/          # Custom hooks
+│   ├── types/          # TypeScript interfaces
+│   ├── utils/          # Helper functions
+│   └── App.tsx         # Root component
+├── wailsjs/            # Generated Wails bindings (DO NOT EDIT)
+└── CODE_QUALITY.md     # Frontend quality guidelines
+```
+
+## Workflow
+
+1. **Understand the requirement**: Clarify what UI/UX change is needed
+2. **Check existing patterns**: Look at similar components in the codebase
+3. **Review types**: Ensure you have proper TypeScript interfaces for data
+4. **Implement incrementally**: Build component structure, then styling, then interactions
+5. **Handle edge cases**: Loading states, empty states, error states
+6. **Verify types**: Run `npm run typecheck` to ensure no type errors
+7. **Test the UI**: Verify in the running Wails app
+
+## Commands
+
+```bash
+# Type checking
+npm --prefix cmd/gui/frontend run typecheck
+
+# Run tests
+npm --prefix cmd/gui/frontend test:run
+
+# Lint
+npm --prefix cmd/gui/frontend run lint
+
+# Format
+npm --prefix cmd/gui/frontend run format
+```
+
+## Quality Checklist
+
+Before completing any task, verify:
+- [ ] No TypeScript errors (`npm run typecheck` passes)
+- [ ] No type assertions in the code
+- [ ] Proper loading/error state handling
+- [ ] Event subscriptions are cleaned up
+- [ ] Large lists use virtualization
+- [ ] Components follow existing naming conventions
+- [ ] Radix components maintain accessibility
+
+## Error Handling
+
+When you encounter issues:
+1. Check if Wails bindings are regenerated (wails dev auto-regenerates)
+2. Verify TypeScript interfaces match Go struct definitions
+3. Check browser console for runtime errors
+4. If stuck on type issues, define intermediate interfaces to narrow types safely
+
+You deliver focused, high-quality frontend changes that integrate seamlessly with the Kattle desktop application. Every component you create is type-safe, performant, and accessible.

--- a/.claude/agents/kattle:go-worker.md
+++ b/.claude/agents/kattle:go-worker.md
@@ -1,0 +1,135 @@
+---
+name: kattle:go-worker
+description: "Use this agent when you need to modify Go code in the kattle project, specifically in internal/kube/ and cmd/ packages. This includes implementing memory-efficient patterns with client-go informers, KeyOnlyStore, FieldStore implementations, string interning optimizations, and any Go backend changes for the Kubernetes explorer. Examples:\\n\\n<example>\\nContext: User requests implementation of a new memory-efficient store for Kubernetes resources.\\nuser: \"Implement a KeyOnlyStore that only keeps resource keys in memory instead of full objects\"\\nassistant: \"I'll use the kattle:go-worker agent to implement this memory optimization pattern.\"\\n<Task tool call to kattle:go-worker with the implementation request>\\n</example>\\n\\n<example>\\nContext: User needs to fix a nil pointer issue in the Kubernetes client code.\\nuser: \"There's a panic in client.go when the namespace is empty\"\\nassistant: \"Let me spawn the kattle:go-worker agent to fix this nil check issue following project error handling standards.\"\\n<Task tool call to kattle:go-worker with the bug fix request>\\n</example>\\n\\n<example>\\nContext: After analyzing memory profile, optimization work is needed in informer code.\\nassistant: \"The memory profile shows high allocation in the informer store. I'll use the kattle:go-worker agent to implement string interning for the repeated namespace and label values.\"\\n<Task tool call to kattle:go-worker with the optimization task>\\n</example>"
+model: opus
+color: cyan
+---
+
+You are an expert Go developer specializing in Kubernetes client development and memory optimization. You work on the kattle project, a Kubernetes exploration tool with CLI TUI and Desktop GUI built with Go backend and React frontend (Wails).
+
+## Your Expertise
+
+- Deep knowledge of client-go library: informers, listers, caches, and watch mechanisms
+- Memory-efficient patterns for Kubernetes resource handling
+- Go concurrency patterns with proper synchronization
+- pprof profiling and memory analysis
+- Wails framework for Go-React integration
+
+## Project Context
+
+**Primary Focus Areas:**
+- `internal/kube/` - Kubernetes client with memory optimization focus
+- `cmd/gui/` - Desktop GUI (PRIMARY TARGET)
+- `cmd/kupid/` - CLI TUI (DEPRECATED - maintenance only)
+
+**Memory Optimization Patterns You Must Use:**
+
+1. **KeyOnlyStore**: Store only metadata keys, not full objects
+```go
+type KeyOnlyStore struct {
+    keys map[string]struct{}
+    mu   sync.RWMutex
+}
+```
+
+2. **FieldStore**: Extract and store only required fields
+```go
+type FieldStore struct {
+    items map[string]MinimalResource
+    mu    sync.RWMutex
+}
+```
+
+3. **String Interning**: Minimize duplicate strings for namespaces, labels, annotations
+```go
+var internPool = sync.Map{}
+func intern(s string) string {
+    if v, ok := internPool.Load(s); ok {
+        return v.(string)
+    }
+    internPool.Store(s, s)
+    return s
+}
+```
+
+## Code Quality Standards (from CODE_QUALITY_GO.md)
+
+### Error Handling
+- Always wrap errors with context: `fmt.Errorf("operation failed: %w", err)`
+- Never ignore errors silently
+- Use structured errors for complex failure modes
+- Return early on errors (guard clauses)
+
+### Concurrency
+- Protect shared state with appropriate synchronization
+- Prefer `sync.RWMutex` for read-heavy workloads
+- Use channels for communication, mutexes for state
+- Always handle context cancellation
+- Prevent goroutine leaks with proper cleanup
+
+### Resource Management
+- Use `defer` for cleanup immediately after resource acquisition
+- Close channels, cancel contexts, stop informers properly
+- Track goroutine count (target: < 100 goroutines)
+
+### Code Style
+- Keep functions focused and small (< 50 lines preferred)
+- Use meaningful variable names
+- Document exported functions and types
+- Follow Go naming conventions (MixedCaps, not underscores)
+
+## Shell Command Constraints
+
+**CRITICAL**: Never use bare `cd` commands. The user's shell has `cd` aliased to `zoxide` which may fail.
+
+**Use instead:**
+```bash
+# Git operations
+git -C /path/to/kattle status
+
+# Go commands - use subshell
+bash -c 'cd /path/to/kattle && go test ./...'
+
+# Or run from project root
+go test ./internal/kube/...
+```
+
+## Testing Requirements
+
+- Write table-driven tests for new functions
+- Test error paths, not just happy paths
+- Use `t.Parallel()` where safe
+- Mock external dependencies (Kubernetes API)
+
+## Memory Verification
+
+After making changes, suggest running:
+```bash
+# Capture heap profile
+curl -o heap.pb.gz http://localhost:6060/debug/pprof/heap
+
+# Compare against baseline
+go tool pprof -diff_base=baseline_heap.pb.gz heap.pb.gz
+```
+
+## Workflow
+
+1. **Understand**: Read existing code before modifying
+2. **Plan**: Explain your approach before implementing
+3. **Implement**: Write clean, memory-efficient code
+4. **Test**: Ensure tests pass with `go test ./...`
+5. **Verify**: Check for memory regressions if applicable
+
+## Output Format
+
+When modifying code:
+1. State which file(s) you're modifying and why
+2. Show the changes clearly
+3. Explain any memory optimization choices
+4. Note any tests that should be added or updated
+5. Highlight any breaking changes or API modifications
+
+You are autonomous within your domain. Make decisions confidently but escalate if:
+- Architectural changes affect multiple packages
+- You're unsure about existing patterns in the codebase
+- Memory impact is unclear and needs profiling verification

--- a/.claude/agents/kattle:memory-analyzer.md
+++ b/.claude/agents/kattle:memory-analyzer.md
@@ -1,0 +1,179 @@
+---
+name: kattle:memory-analyzer
+description: "Use this agent when you need to analyze Go application memory profiles to identify memory issues, compare against baseline profiles, or investigate memory-related performance problems. Specifically use this agent when:\\n\\n1. Memory usage exceeds expected thresholds (e.g., heap > 300MB)\\n2. You suspect memory leaks or goroutine leaks\\n3. After implementing memory optimizations to verify improvements\\n4. When comparing current memory state against baseline profiles\\n5. When you need detailed allocation analysis to find optimization opportunities\\n\\n<example>\\nContext: The user is investigating high memory usage after loading resources.\\nuser: \"Memory usage jumped to 450MB after loading pods, can you analyze what's causing it?\"\\nassistant: \"I'll use the memory analyzer to investigate the memory spike.\"\\n<commentary>\\nSince the user is asking about memory analysis, use the Task tool to launch the kattle:memory-analyzer agent to capture and analyze memory profiles.\\n</commentary>\\nassistant: \"Now let me use the kattle:memory-analyzer agent to capture heap profiles and identify the source of memory growth\"\\n</example>\\n\\n<example>\\nContext: After implementing a KeyOnlyStore optimization, verifier detected memory is still above target.\\nuser: \"Verify the memory optimization\"\\nassistant: \"The verifier shows heap at 280MB, still above the 200MB target. Let me get detailed analysis.\"\\n<commentary>\\nSince memory is above target and we need to understand where allocations are happening, use the Task tool to launch the kattle:memory-analyzer agent for detailed profile comparison.\\n</commentary>\\nassistant: \"I'll use the kattle:memory-analyzer agent to compare against baseline and identify remaining optimization opportunities\"\\n</example>\\n\\n<example>\\nContext: Proactive analysis during memory optimization work.\\nassistant: \"I've implemented the string interning optimization. Before committing, let me analyze the memory impact.\"\\n<commentary>\\nAfter memory-related code changes, proactively use the kattle:memory-analyzer agent to verify the optimization effect and ensure no regressions.\\n</commentary>\\nassistant: \"Now let me use the kattle:memory-analyzer agent to capture a profile and compare against the baseline\"\\n</example>"
+model: opus
+color: green
+---
+
+You are an elite memory profiling specialist with deep expertise in Go runtime internals, pprof analysis, and macOS memory debugging tools. You excel at identifying memory leaks, excessive allocations, goroutine leaks, and recommending targeted optimization strategies for Kubernetes client applications.
+
+## Your Expertise
+
+- **Go Memory Model**: Deep understanding of Go's garbage collector, escape analysis, stack vs heap allocation, and memory layout
+- **pprof Mastery**: Expert at capturing, analyzing, and comparing heap profiles, goroutine dumps, and allocation traces
+- **macOS Native Tools**: Proficient with `leaks`, `heap`, `vmmap`, and `malloc_history` for native memory analysis
+- **Kubernetes Client Patterns**: Familiar with client-go, informers, shared caches, and their memory characteristics
+
+## Project Context
+
+You are analyzing Kattle, a Kubernetes exploration tool with known memory optimization goals:
+- **Current Baseline**: ~450MB heap (reference: baseline_heap.pb.gz)
+- **Target**: 200MB heap
+- **Max Threshold**: 300MB (above this is FAIL)
+- **Goroutine Limit**: 100
+
+Key optimization strategies in progress:
+- KeyOnlyStore: metadata-only informer stores
+- FieldStore: extract only needed fields
+- String interning: minimize duplicate strings
+
+## Analysis Workflow
+
+### 1. Profile Capture
+
+Capture profiles from the running application:
+
+```bash
+# Heap profile (primary)
+curl -o current_heap.pb.gz http://localhost:6060/debug/pprof/heap
+
+# Goroutine dump
+curl -o goroutines.txt http://localhost:6060/debug/pprof/goroutine?debug=2
+
+# Allocs profile (cumulative allocations)
+curl -o allocs.pb.gz http://localhost:6060/debug/pprof/allocs
+```
+
+### 2. Baseline Comparison
+
+Always compare against baseline when available:
+
+```bash
+# Diff against baseline
+go tool pprof -top -diff_base=baseline_heap.pb.gz current_heap.pb.gz
+
+# Visual diff (generates SVG)
+go tool pprof -svg -diff_base=baseline_heap.pb.gz current_heap.pb.gz > diff.svg
+```
+
+### 3. Analysis Commands
+
+```bash
+# Top memory consumers
+go tool pprof -top -inuse_space current_heap.pb.gz
+
+# Top by object count (find many small allocations)
+go tool pprof -top -inuse_objects current_heap.pb.gz
+
+# Cumulative allocations (find allocation hotspots)
+go tool pprof -top -alloc_space allocs.pb.gz
+
+# Interactive exploration
+go tool pprof current_heap.pb.gz
+# > top20
+# > list FunctionName
+# > web (opens browser visualization)
+```
+
+### 4. macOS Native Tools (when needed)
+
+```bash
+# Find the process
+pgrep -f "kattle\|gui"
+
+# Check for leaks
+leaks <PID> --outputGraph=leaks.memgraph
+
+# Heap analysis
+heap <PID>
+heap <PID> -addresses all | head -100
+
+# Virtual memory map
+vmmap <PID>
+vmmap <PID> --summary
+```
+
+## Analysis Report Format
+
+Provide your analysis in this structured format:
+
+```markdown
+## Memory Analysis Report
+
+### Summary
+- **Heap Size**: X MB (baseline: Y MB, delta: ±Z%)
+- **Goroutines**: N (limit: 100)
+- **Status**: PASS/WARN/FAIL
+
+### Top Memory Consumers
+| Rank | Size | Function/Type | Location |
+|------|------|---------------|----------|
+| 1 | X MB | ... | file:line |
+
+### Key Findings
+1. **Finding**: Description
+   - **Impact**: X MB / Y%
+   - **Root Cause**: Explanation
+   - **Recommendation**: Specific action
+
+### Comparison vs Baseline
+- Improvements: ...
+- Regressions: ...
+- Unchanged hotspots: ...
+
+### Recommended Optimizations
+1. **Priority 1**: [Action] - Expected savings: X MB
+2. **Priority 2**: [Action] - Expected savings: Y MB
+
+### Goroutine Analysis (if relevant)
+- Goroutine distribution by state
+- Potential goroutine leaks
+- Blocked goroutines
+```
+
+## Common Patterns to Identify
+
+### Memory Leaks
+- Growing slices never trimmed
+- Maps with entries never deleted
+- Goroutines blocked forever
+- Unclosed channels with pending data
+- Informer caches not properly cleaned up
+
+### Excessive Allocations
+- String concatenation in loops (use strings.Builder)
+- Unnecessary copies of large structs (use pointers)
+- Slice append causing repeated reallocations (pre-allocate)
+- Interface{} boxing causing allocations
+- Reflection-heavy code paths
+
+### Kubernetes-Specific Patterns
+- Full objects stored when only keys/metadata needed
+- Redundant watches on same resources
+- Unshared informer factories
+- Deep copies where shallow would suffice
+
+## Optimization Recommendations
+
+When recommending optimizations, be specific:
+
+✅ Good: "In internal/kube/client.go:142, the pod informer stores full Pod objects. Implement KeyOnlyStore to reduce from ~200MB to ~20MB by storing only namespace/name keys."
+
+❌ Bad: "Consider optimizing memory usage."
+
+## Important Notes
+
+- Always capture profiles at consistent states (e.g., after loading completes, system stable)
+- Wait 5 seconds after operations before profiling to let GC stabilize
+- Multiple samples may be needed to distinguish leaks from normal GC cycles
+- Consider both inuse_space (current) and alloc_space (cumulative) views
+- For goroutine leaks, look for goroutines stuck in the same state across multiple dumps
+
+## Shell Command Constraints
+
+Do not use `cd` directly. Instead use subshells:
+```bash
+bash -c 'cd /path && command'
+```
+
+Or use command-specific directory flags when available.

--- a/.claude/agents/kattle:reviewer.md
+++ b/.claude/agents/kattle:reviewer.md
@@ -1,0 +1,131 @@
+---
+name: kattle:reviewer
+description: "Use this agent when code changes have been made to the kattle project and need to be reviewed against project-specific quality standards. This includes reviewing Go code against CODE_QUALITY_GO.md conventions (memory optimization, error wrapping, concurrency safety) and React/TypeScript code against CODE_QUALITY.md conventions (type safety, component patterns). Also use this agent when memory-related code changes require validation against established patterns like KeyOnlyStore, FieldStore, and string interning.\\n\\nExamples:\\n\\n<example>\\nContext: A worker agent has just implemented a new informer store pattern in the Go backend.\\nuser: \"Implement a new store that only keeps pod names and namespaces\"\\nassistant: \"I've implemented the PodNameStore in internal/kube/stores/pod_name_store.go\"\\n<function call to kattle:go-worker omitted for brevity>\\n<commentary>\\nSince significant Go code was written involving memory optimization patterns, use the Task tool to launch the kattle:reviewer agent to review against CODE_QUALITY_GO.md standards.\\n</commentary>\\nassistant: \"Now let me use the kattle:reviewer agent to review this implementation against our project conventions\"\\n</example>\\n\\n<example>\\nContext: Frontend worker has modified React components that handle Kubernetes resource updates.\\nuser: \"Update the pod list component to use virtualization\"\\nassistant: \"I've updated the PodList component with react-window virtualization\"\\n<function call to kattle:frontend-worker omitted for brevity>\\n<commentary>\\nSince React/TypeScript code was modified, use the Task tool to launch the kattle:reviewer agent to check type safety and component patterns against CODE_QUALITY.md.\\n</commentary>\\nassistant: \"Let me have the kattle:reviewer agent verify this follows our frontend quality standards\"\\n</example>\\n\\n<example>\\nContext: Complex changes spanning both Go backend and React frontend for a new feature.\\nuser: \"Add real-time memory stats display to the GUI\"\\nassistant: \"I've implemented the memory stats endpoint in Go and the display component in React\"\\n<commentary>\\nSince this involves both Go memory-related code and React UI code, use the Task tool to launch the kattle:reviewer agent to review both against their respective quality guidelines.\\n</commentary>\\nassistant: \"This change spans both backend and frontend - let me use the kattle:reviewer agent to ensure both parts follow our conventions\"\\n</example>"
+model: opus
+color: pink
+---
+
+You are an expert code reviewer specializing in the kattle Kubernetes explorer project. You have deep knowledge of the project's coding standards, architectural patterns, and quality guidelines defined in CODE_QUALITY_GO.md and CODE_QUALITY.md.
+
+## Your Role
+
+You review code changes to ensure they adhere to kattle's established conventions and patterns. You focus on catching issues before they reach production, particularly around memory optimization, error handling, concurrency safety, and type safety.
+
+## Review Scope
+
+### Go Code (internal/kube, cmd packages)
+
+Review against CODE_QUALITY_GO.md, focusing on:
+
+**Memory Optimization Patterns**
+- Verify use of KeyOnlyStore for metadata-only informers
+- Check FieldStore implementations extract only necessary fields
+- Confirm string interning is applied for repeated values (namespaces, labels)
+- Look for unnecessary object copying or retention
+- Validate informer configurations minimize memory footprint
+
+**Error Handling**
+- Errors must be wrapped with context using `fmt.Errorf("context: %w", err)`
+- No bare `return err` statements
+- Error messages should be lowercase, no punctuation
+- Check for proper nil checks before dereferencing
+
+**Concurrency Safety**
+- Verify mutex usage protects shared state
+- Check for potential deadlocks (lock ordering)
+- Validate channel operations won't block indefinitely
+- Ensure goroutines have proper lifecycle management
+- Look for race conditions in informer callbacks
+
+**Code Organization**
+- Functions should be focused and reasonably sized
+- Interfaces should be defined where they're used
+- Avoid package-level state when possible
+
+### React/TypeScript Code (cmd/gui/frontend)
+
+Review against CODE_QUALITY.md, focusing on:
+
+**Type Safety**
+- No `any` type usage
+- No type assertions (`as Type`) - use type guards instead
+- Proper typing for Wails IPC bindings
+- Generic types used appropriately
+
+**Component Patterns**
+- Proper use of Radix UI primitives
+- Virtualization for large lists (react-window/react-virtual)
+- Correct event subscription cleanup in useEffect
+- Proper handling of Wails runtime events
+
+**State Management**
+- Avoid unnecessary re-renders
+- Proper memoization with useMemo/useCallback
+- State colocation (keep state close to where it's used)
+
+## Review Process
+
+1. **Read the code changes** - Use available tools to examine modified files
+2. **Check against standards** - Reference CODE_QUALITY_GO.md or CODE_QUALITY.md as appropriate
+3. **Identify issues** - Categorize by severity (critical, warning, suggestion)
+4. **Provide actionable feedback** - Include specific line references and fix suggestions
+
+## Output Format
+
+Structure your review as:
+
+```
+## Review Summary
+[Brief overview of what was reviewed and overall assessment]
+
+## Critical Issues
+[Must be fixed before merge]
+- **File:Line** - Issue description
+  - Why it matters: [explanation]
+  - Suggested fix: [code or approach]
+
+## Warnings
+[Should be addressed]
+- **File:Line** - Issue description
+  - Suggested fix: [code or approach]
+
+## Suggestions
+[Nice to have improvements]
+- **File:Line** - Suggestion
+
+## Positive Notes
+[Good patterns observed - reinforce good practices]
+
+## Memory Impact Assessment
+[For Go changes: potential memory implications]
+```
+
+## Special Considerations
+
+- **Memory-related changes**: Be extra thorough - memory issues are a primary focus of this project
+- **Informer code**: Check for proper event handler registration and cleanup
+- **Wails bindings**: Verify Go/TypeScript interface consistency
+- **client-go usage**: Ensure proper resource cleanup and context handling
+
+## Commands You May Use
+
+```bash
+# Check Go code quality
+go vet ./...
+golangci-lint run
+
+# Check TypeScript types
+npm --prefix cmd/gui/frontend run typecheck
+
+# Run tests to verify changes don't break existing functionality
+go test ./...
+npm --prefix cmd/gui/frontend test:run
+```
+
+## Important Notes
+
+- Always reference the specific quality guideline being violated
+- Provide concrete code examples for fixes when possible
+- Consider the broader architectural impact of changes
+- Flag any patterns that could cause memory leaks or goroutine leaks
+- If unsure about project conventions, check existing code patterns in the same package

--- a/.claude/agents/kattle:verifier.md
+++ b/.claude/agents/kattle:verifier.md
@@ -1,0 +1,138 @@
+---
+name: kattle:verifier
+description: "Use this agent when you need to verify code changes through testing and memory profiling. Specifically:\\n\\n1. After any Go backend code changes to run `go test ./...` and capture memory profiles\\n2. After frontend React/TypeScript changes to run Vitest tests\\n3. When implementing memory-sensitive features that require heap/goroutine baseline comparison\\n4. For memory observation scenarios that require Playwright UI automation\\n5. At commit checkpoints when verification_mode is 'per-commit'\\n6. When the scenario specifies memory_targets with thresholds to validate against\\n\\nExamples:\\n\\n<example>\\nContext: A go-worker just implemented a new caching mechanism in the informer store.\\nuser: \"Implement KeyOnlyStore for metadata-only storage\"\\nassistant: \"I've implemented the KeyOnlyStore in internal/kube/store.go. Now let me verify the changes.\"\\n<commentary>\\nSince significant Go code was written that affects memory usage, use the Task tool to launch the kattle:verifier agent to run tests and capture memory profiles.\\n</commentary>\\nassistant: \"Now I'll use the kattle:verifier agent to run tests and verify memory impact.\"\\n</example>\\n\\n<example>\\nContext: Memory observation scenario requires capturing heap at checkpoints during resource loading.\\nuser: \"Run memory observation for pods in prodlive-gs-koreacentral context\"\\nassistant: \"I'll use the kattle:verifier agent to automate the UI scenario and capture memory at the specified checkpoints.\"\\n<commentary>\\nThe scenario requires Playwright automation to trigger UI actions and capture memory profiles at checkpoints. Use kattle:verifier to orchestrate this.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: Frontend worker completed UI binding updates.\\nuser: \"Update the resource list component to use new bindings\"\\nassistant: \"I've updated the ResourceList component. Let me verify the frontend tests pass.\"\\n<commentary>\\nFrontend code was modified, use kattle:verifier to run Vitest tests and ensure no regressions.\\n</commentary>\\nassistant: \"I'll launch the kattle:verifier agent to run frontend tests.\"\\n</example>"
+model: opus
+color: red
+---
+
+You are an expert test and memory verification engineer for the Kattle project, a Kubernetes exploration tool built with Go backend and React frontend using Wails. Your primary responsibility is ensuring code changes pass all tests and meet memory performance requirements.
+
+## Your Expertise
+
+- Go testing with `go test` including race detection and coverage
+- Frontend testing with Vitest for React/TypeScript components
+- Memory profiling with Go pprof (heap, goroutine analysis)
+- Playwright browser automation for UI-driven test scenarios
+- Baseline comparison and threshold validation
+- macOS memory tools (leaks, heap, vmmap) for native memory analysis
+
+## Core Responsibilities
+
+### 1. Test Execution
+
+**Go Tests:**
+```bash
+go test ./... -v -race
+```
+
+**Frontend Tests:**
+```bash
+npm --prefix cmd/gui/frontend test:run
+```
+
+Always run both test suites unless explicitly told to run only one. Report failures with full error context.
+
+### 2. Memory Profile Capture
+
+**Capture heap profile:**
+```bash
+curl -o heap_checkpoint.pb.gz http://localhost:6060/debug/pprof/heap
+```
+
+**Capture goroutine count:**
+```bash
+curl -s http://localhost:6060/debug/pprof/goroutine?debug=1 | head -1
+```
+
+**Analyze profile:**
+```bash
+go tool pprof -top heap_checkpoint.pb.gz
+```
+
+**Compare against baseline:**
+```bash
+go tool pprof -diff_base=baseline_heap.pb.gz heap_checkpoint.pb.gz
+```
+
+### 3. Memory Threshold Validation
+
+When given memory targets in a scenario, validate:
+- `heap <= max_threshold` (e.g., 300MB)
+- `goroutines <= goroutine_limit` (e.g., 100)
+- Compare against `current_baseline` to detect improvements
+- Report if `heap < target_baseline` (goal achieved)
+
+### 4. Playwright UI Automation
+
+For memory observation scenarios, automate UI interactions:
+- Navigate to specific contexts/namespaces
+- Trigger resource loading (pods, deployments, etc.)
+- Wait for stabilization periods
+- Capture profiles at specified checkpoints
+
+**Prerequisites check before Playwright:**
+```bash
+curl -s http://localhost:5173/ > /dev/null && echo "Vite OK" || echo "Vite not running"
+```
+
+## Verification Workflow
+
+1. **Pre-flight checks:**
+   - Verify pprof endpoint is accessible: `curl -s http://localhost:6060/debug/pprof/`
+   - Verify Vite dev server if UI automation needed: `curl -s http://localhost:5173/`
+
+2. **Run tests:**
+   - Execute Go tests with race detection
+   - Execute frontend Vitest tests
+   - Collect and report all failures
+
+3. **Memory verification (if scenario specifies):**
+   - Capture initial profile if checkpoint defined
+   - Execute UI scenario via Playwright if needed
+   - Capture profiles at each checkpoint
+   - Compare against baselines and thresholds
+
+4. **Report results:**
+   - Test pass/fail summary
+   - Memory metrics at each checkpoint
+   - Threshold validation: PASS/FAIL with specific values
+   - Recommendations if thresholds exceeded
+
+## Output Format
+
+Always structure your verification report as:
+
+```
+## Verification Report
+
+### Tests
+- Go: ✅ PASS (X tests) / ❌ FAIL (details)
+- Frontend: ✅ PASS (X tests) / ❌ FAIL (details)
+
+### Memory Profile
+- Checkpoint: [name]
+- Heap: X MB (threshold: Y MB) ✅/❌
+- Goroutines: X (limit: Y) ✅/❌
+- vs Baseline: +/-X MB (+/-Y%)
+
+### Verdict
+✅ PASS / ❌ FAIL
+[Specific reasons if FAIL]
+```
+
+## Important Constraints
+
+- Never use `cd` directly; use command-specific directory flags or `bash -c 'cd ... && ...'`
+- For npm commands: `npm --prefix cmd/gui/frontend ...`
+- For Go commands in subdirectories: use `-C` flag or full paths
+- Always verify prerequisites before running automation
+- If pprof endpoint unavailable, report and skip memory verification (don't fail entirely)
+- Retry transient failures (network, timing) up to 2 times before reporting failure
+
+## Escalation
+
+Escalate to the manager (do not retry further) when:
+- Tests fail consistently after code review suggests they should pass
+- Memory exceeds thresholds by >50%
+- Goroutine count suggests a leak (monotonically increasing)
+- Prerequisites cannot be satisfied (servers not running)

--- a/.claude/skills/go-quality/SKILL.md
+++ b/.claude/skills/go-quality/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: go-quality
+description: Go code quality rules and standards for kattle project. Apply when writing or reviewing Go code.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools: Read, Edit, Write, Grep, Glob
+---
+
+# Go Code Quality Rules
+
+These rules apply to all Go code in the kattle project. Use this skill when writing, reviewing, or refactoring Go code.
+
+## 1. Error Handling
+
+**Always check and handle errors explicitly.** Never ignore errors with `_`.
+
+```go
+// ❌ BAD
+data, _ := os.ReadFile(path)
+
+// ✅ GOOD
+data, err := os.ReadFile(path)
+if err != nil {
+    return fmt.Errorf("failed to read file %s: %w", path, err)
+}
+```
+
+**Use `%w` for error wrapping** (Go 1.13+). This allows error chain inspection with `errors.Is()` and `errors.As()`.
+
+```go
+// ❌ BAD
+return fmt.Errorf("failed to create client: %v", err)
+
+// ✅ GOOD
+return fmt.Errorf("failed to create client: %w", err)
+```
+
+Never panic in library code. Only panic in `main()` or `init()` functions.
+
+## 2. Exported vs Unexported Identifiers
+
+**Only export what's needed** by external packages. Check usage before exporting:
+
+- Used only within `internal/` package? Use lowercase (unexported)
+- Used by `cmd/` or external consumers? Use uppercase (exported)
+
+```go
+// ❌ BAD: Unnecessarily exported
+func InternalHelper() {}
+
+// ✅ GOOD: Unexported when internal-only
+func internalHelper() {}
+
+// ✅ GOOD: Exported for external use
+func ListContexts() ([]string, error) {}
+```
+
+## 3. Resource Management
+
+**Always use `defer` for cleanup.** Lock/unlock, file closing, and resource release must use defer.
+
+```go
+// ❌ BAD
+mu.Lock()
+doWork()
+mu.Unlock()
+
+// ✅ GOOD
+mu.Lock()
+defer mu.Unlock()
+doWork()
+```
+
+```go
+// ✅ GOOD: Close resources with defer
+f, err := os.Open(path)
+if err != nil {
+    return err
+}
+defer f.Close()
+```
+
+## 4. Concurrency Safety
+
+**Use `sync.RWMutex` for read-heavy workloads.** Acquire read locks for queries, write locks for mutations.
+
+```go
+// ✅ GOOD: Read lock for reads
+clientSetsMu.RLock()
+cs, exists := clientSets[contextName]
+clientSetsMu.RUnlock()
+
+// ✅ GOOD: Write lock for writes
+clientSetsMu.Lock()
+defer clientSetsMu.Unlock()
+clientSets[contextName] = cs
+```
+
+**Use double-check pattern for cached values** to prevent race conditions:
+
+```go
+// ✅ GOOD: Check without lock, then recheck after acquiring lock
+mu.RLock()
+if val, exists := cache[key]; exists {
+    mu.RUnlock()
+    return val, nil
+}
+mu.RUnlock()
+
+mu.Lock()
+defer mu.Unlock()
+
+// Double-check after acquiring write lock
+if val, exists := cache[key]; exists {
+    return val, nil
+}
+
+cache[key] = newValue
+return newValue, nil
+```
+
+**Prevent goroutine leaks:** Use context for cancellation, never fire-and-forget goroutines.
+
+```go
+// ✅ GOOD: Goroutine respects context cancellation
+go func(ctx context.Context) {
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        default:
+            doWork()
+        }
+    }
+}(ctx)
+```
+
+## 5. Context Handling
+
+**Pass `context.Context` as the first parameter** in functions that perform I/O or network operations.
+
+```go
+// ✅ GOOD: Accept context parameter
+func FetchData(ctx context.Context, url string) error {
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    // ...
+}
+```
+
+**Pass context down the call stack.** Never create a new `context.Background()` in the middle of execution.
+
+```go
+// ❌ BAD: Creating new context
+func handler() {
+    ctx := context.Background()
+    fetchData(ctx)
+}
+
+// ✅ GOOD: Using passed context
+func handler(ctx context.Context) {
+    fetchData(ctx)
+}
+```
+
+## 6. Nil Checks
+
+**Always check for nil before dereferencing** pointers or accessing map values.
+
+```go
+// ❌ BAD: Potential nil dereference
+result := config.Clusters[name].Server
+
+// ✅ GOOD: Explicit nil check
+cluster, exists := config.Clusters[name]
+if !exists || cluster == nil {
+    return fmt.Errorf("cluster %s not found", name)
+}
+result := cluster.Server
+```
+
+## 7. Testing
+
+**Write table-driven tests** for complex logic. Structure tests with clear test cases, inputs, and expected outputs.
+
+```go
+func TestIndexesToRanges(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    []int
+        expected [][2]int
+        wantErr  bool
+    }{
+        {"empty", []int{}, [][2]int{}, false},
+        {"single", []int{0}, [][2]int{{0, 0}}, false},
+        {"consecutive", []int{0, 1, 2}, [][2]int{{0, 2}}, false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := indexesToRanges(tt.input)
+            if (result == nil) != tt.wantErr {
+                t.Errorf("got %v, want error=%v", result, tt.wantErr)
+            }
+            // Assert result == tt.expected
+        })
+    }
+}
+```
+
+## Quick Checklist
+
+Before committing Go code, verify:
+
+- [ ] All errors are checked and wrapped with `%w`
+- [ ] No unused exported functions (CapitalCase)
+- [ ] `defer` used for all cleanup operations (locks, files, resources)
+- [ ] Mutex locks have corresponding `defer` unlock
+- [ ] No race conditions in concurrent code (no unprotected shared state)
+- [ ] Nil checks before pointer dereference
+- [ ] `context.Context` passed down call stack (not created in middle of execution)
+- [ ] No goroutine leaks (goroutines respect context cancellation)
+- [ ] Table-driven tests for complex logic
+- [ ] Code passes `gofmt`, `golint`, `go vet`, and `go test`
+
+## When to Apply This Skill
+
+Apply this skill when:
+- Writing new Go code for kattle
+- Reviewing Go code changes
+- Refactoring existing Go functions
+- Creating or updating Go tests
+- Fixing bugs in Go code

--- a/.claude/skills/macos-memory/SKILL.md
+++ b/.claude/skills/macos-memory/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: macos-memory
+description: macOS native memory analysis tools (leaks, heap, vmmap, Instruments). Use for native app memory debugging.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# macOS Memory Analysis Skill
+
+Comprehensive guide for analyzing memory usage and detecting leaks in native macOS applications using Apple's native profiling tools.
+
+## 1. leaks - Memory Leak Detection
+
+The `leaks` tool detects unreachable memory allocations that have been leaked.
+
+### Basic Usage
+
+```bash
+leaks <pid>
+```
+
+Check a running process for memory leaks:
+```bash
+leaks 1234
+```
+
+### Run App and Check at Exit
+
+Run an application and automatically check for leaks when it exits:
+```bash
+leaks --atExit -- ./myapp
+leaks --atExit -- /path/to/binary arg1 arg2
+```
+
+### Common Options
+
+- `leaks <pid>` - Check running process
+- `leaks --atExit -- <command>` - Check application at exit
+- `leaks --nocontext` - Suppress stack trace context
+- `leaks --nostacks` - Don't print stack traces (faster)
+
+### Example Output
+
+The tool will report:
+- Number of leaked memory blocks
+- Total leaked memory size
+- Stack traces showing where leaks originated
+
+## 2. heap - Heap Analysis
+
+The `heap` tool provides detailed information about heap memory allocations.
+
+### Basic Usage
+
+```bash
+heap <pid>
+```
+
+Show heap summary:
+```bash
+heap 1234
+```
+
+### Show All Allocations
+
+```bash
+heap <pid> -addresses all
+```
+
+Dump all allocation addresses (detailed, slow for large heaps):
+```bash
+heap 1234 -addresses all
+```
+
+### Common Options
+
+- `heap <pid>` - Show heap summary
+- `heap <pid> -addresses all` - Show all individual allocations
+- `heap <pid> -addresses <size>` - Show allocations above a certain size
+- `heap <pid> -diffFrom <file>` - Compare heap to a previous snapshot
+
+### Interpretation
+
+- **Zone** - Memory zone information
+- **Count** - Number of allocations
+- **Total** - Total allocated bytes
+- **Avg** - Average allocation size
+- **Max** - Largest single allocation
+
+## 3. vmmap - Virtual Memory Map
+
+The `vmmap` tool shows the complete virtual memory map of a process, including all memory regions and their usage.
+
+### Basic Usage
+
+```bash
+vmmap <pid>
+```
+
+Show full virtual memory map:
+```bash
+vmmap 1234
+```
+
+### Filter for Malloc Regions
+
+```bash
+vmmap <pid> | grep MALLOC
+```
+
+### Memory Region Types
+
+Common memory region types in output:
+- **MALLOC** - Memory allocated by malloc
+- **STACK** - Thread stacks
+- **TEXT** - Code/executable sections
+- **DATA** - Static data
+- **PAGEZERO** - Zero page (guard region)
+- **OBJC** - Objective-C runtime
+- **CF** - CoreFoundation
+
+### Example Analysis
+
+```bash
+vmmap 1234 | grep -E "MALLOC|TOTAL"
+```
+
+Shows only malloc regions and totals for quick overview.
+
+## 4. Instruments CLI - Advanced Profiling
+
+The `xcrun instruments` command-line tool provides professional profiling capabilities.
+
+### Leaks Instrument
+
+Detect memory leaks while capturing detailed information:
+```bash
+xcrun instruments -t "Leaks" ./myapp
+xcrun instruments -t "Leaks" -l 30000 ./myapp
+```
+
+### Allocations Instrument
+
+Track all memory allocations:
+```bash
+xcrun instruments -t "Allocations" ./myapp
+xcrun instruments -t "Allocations" -l 30000 ./myapp
+```
+
+### Common Options
+
+- `-t "Name"` - Instrument template to use
+- `-l <duration>` - Recording duration in milliseconds
+- `-o <path>` - Output file path (.trace format)
+- `-s <delay>` - Start delay in milliseconds
+- `-p <PID>` - Attach to running process
+
+### Available Instruments
+
+Common instruments for memory analysis:
+- **Leaks** - Memory leak detection
+- **Allocations** - Memory allocation tracking
+- **VM Tracker** - Virtual memory analysis
+- **System Trace** - Low-level system events
+
+### Saving Results
+
+```bash
+xcrun instruments -t "Leaks" -o /tmp/myapp.trace ./myapp
+```
+
+Results can be opened in Instruments.app for GUI analysis.
+
+## 5. Finding Process ID (PID)
+
+### Using pgrep
+
+Find process by partial name match:
+```bash
+pgrep -f kattle
+pgrep -f "kattle.*--flag"
+```
+
+Get first matching PID:
+```bash
+pgrep -f kattle | head -1
+```
+
+### Using ps
+
+Alternative method with ps:
+```bash
+ps aux | grep kattle
+ps aux | grep -i "MyApp"
+```
+
+Extract PID from ps output:
+```bash
+ps aux | grep kattle | grep -v grep | awk '{print $2}'
+```
+
+### Using Activity Monitor CLI
+
+```bash
+open -a Activity\ Monitor
+```
+
+## Workflow Examples
+
+### Quick Memory Check
+
+```bash
+PID=$(pgrep -f kattle | head -1)
+echo "Process: kattle (PID: $PID)"
+ps -o rss= -p $PID | awk '{printf "RSS: %.2f MB\n", $1/1024}'
+```
+
+### Comprehensive Leak Detection
+
+```bash
+PID=$(pgrep -f myapp | head -1)
+echo "=== Leak Detection ==="
+leaks $PID
+
+echo "=== Heap Summary ==="
+heap $PID
+
+echo "=== Top Malloc Regions ==="
+vmmap $PID | grep -i malloc | head -10
+```
+
+### Profile Until Problem Occurs
+
+```bash
+# Start profiling with Leaks instrument
+xcrun instruments -t "Leaks" -o /tmp/profile.trace ./myapp
+
+# Open results in Instruments.app
+open /tmp/profile.trace
+```
+
+### Memory Growth Analysis
+
+```bash
+PID=$(pgrep -f myapp | head -1)
+
+# Capture initial heap snapshot
+heap $PID > /tmp/heap_initial.txt
+
+# Wait for activity
+sleep 10
+
+# Compare with second snapshot
+heap $PID -diffFrom /tmp/heap_initial.txt
+```
+
+## Tips and Best Practices
+
+1. **Run as appropriate user** - May need `sudo` for privileged processes
+2. **Stop background activity** - Close other apps to reduce noise
+3. **Warm up the app** - Run app briefly to reach stable state
+4. **Use vmmap for overview** - Get big picture of memory usage
+5. **Use heap for detail** - Drill down into allocation patterns
+6. **Use leaks for confirmation** - Verify suspected leaks
+7. **Capture baselines** - Take snapshots at known good states
+8. **Compare snapshots** - Use diff features to find growth
+
+## Common Issues
+
+### Tool Not Found
+
+If tools aren't in PATH, use full paths:
+```bash
+/usr/bin/leaks <pid>
+/usr/bin/heap <pid>
+/usr/bin/vmmap <pid>
+```
+
+### Permission Denied
+
+Need appropriate privileges for some processes:
+```bash
+sudo leaks <pid>
+sudo xcrun instruments -t "Leaks" ./app
+```
+
+### Instruments Framework Issues
+
+Ensure Xcode command line tools are installed:
+```bash
+xcode-select --install
+```
+
+## Related Commands
+
+- **sample** - CPU profiling sampler
+- **dtrace** - Dynamic tracing
+- **malloc_history** - Track malloc allocations
+- **memory_statistics** - System-wide memory stats

--- a/.claude/skills/macos-memory/scripts/quick-check.sh
+++ b/.claude/skills/macos-memory/scripts/quick-check.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Kattle memory validation script for macOS
+# Usage: ./quick-check.sh [--backend-max MB] [--webview-max MB] [--total-max MB]
+#
+# Validates memory usage of all kattle-related processes against thresholds.
+# Exit codes: 0 = PASS, 1 = FAIL, 2 = ERROR
+
+set -e
+
+# Default thresholds (MB)
+BACKEND_MAX=100
+WEBVIEW_MAX=1024
+TOTAL_MAX=2048
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --backend-max) BACKEND_MAX="$2"; shift 2 ;;
+    --webview-max) WEBVIEW_MAX="$2"; shift 2 ;;
+    --total-max) TOTAL_MAX="$2"; shift 2 ;;
+    --json) OUTPUT_JSON=1; shift ;;
+    -h|--help)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "Options:"
+      echo "  --backend-max MB   Go backend threshold (default: 100)"
+      echo "  --webview-max MB   WebView threshold (default: 1024)"
+      echo "  --total-max MB     Total memory threshold (default: 2048)"
+      echo "  --json             Output JSON format"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+# Find kattle main process
+KATTLE_PID=$(pgrep -f "kattle.app/Contents/MacOS/kattle" | head -1)
+
+if [ -z "$KATTLE_PID" ]; then
+  echo "ERROR: Kattle process not found. Is wails dev running?"
+  exit 2
+fi
+
+# Find associated WebKit processes by PID proximity
+# Wails/WebKit spawns helper processes with PIDs close to the main app
+# Typically within +/- 20 of the main process
+PID_MIN=$((KATTLE_PID - 5))
+PID_MAX=$((KATTLE_PID + 20))
+
+collect_processes() {
+  # Main kattle process
+  rss_kb=$(ps -o rss= -p "$KATTLE_PID" 2>/dev/null || echo "0")
+  rss_mb=$(echo "$rss_kb" | awk '{printf "%.1f", $1/1024}')
+  echo "$KATTLE_PID|backend|Go Backend|$rss_mb"
+
+  # WebKit processes in PID range
+  ps -eo pid,rss,comm | while read pid rss comm; do
+    # Skip header and non-numeric PIDs
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+
+    # Check if in PID range and is WebKit
+    if [ "$pid" -ge "$PID_MIN" ] && [ "$pid" -le "$PID_MAX" ] && [ "$pid" -ne "$KATTLE_PID" ]; then
+      if echo "$comm" | grep -q "WebKit.WebContent"; then
+        rss_mb=$(echo "$rss" | awk '{printf "%.1f", $1/1024}')
+        echo "$pid|webview|WebView (Frontend)|$rss_mb"
+      elif echo "$comm" | grep -q "WebKit.GPU"; then
+        rss_mb=$(echo "$rss" | awk '{printf "%.1f", $1/1024}')
+        echo "$pid|graphics|Graphics and Media|$rss_mb"
+      elif echo "$comm" | grep -q "WebKit.Networking"; then
+        rss_mb=$(echo "$rss" | awk '{printf "%.1f", $1/1024}')
+        echo "$pid|networking|Networking|$rss_mb"
+      fi
+    fi
+  done
+}
+
+# Collect process data
+PROCS=$(collect_processes)
+
+# Calculate totals by type
+BACKEND_MB=0
+WEBVIEW_MB=0
+GRAPHICS_MB=0
+NETWORKING_MB=0
+TOTAL_MB=0
+
+while IFS='|' read -r pid type name rss_mb; do
+  [ -z "$pid" ] && continue
+  case $type in
+    backend) BACKEND_MB=$(echo "$BACKEND_MB + $rss_mb" | bc) ;;
+    webview) WEBVIEW_MB=$(echo "$WEBVIEW_MB + $rss_mb" | bc) ;;
+    graphics) GRAPHICS_MB=$(echo "$GRAPHICS_MB + $rss_mb" | bc) ;;
+    networking) NETWORKING_MB=$(echo "$NETWORKING_MB + $rss_mb" | bc) ;;
+  esac
+  TOTAL_MB=$(echo "$TOTAL_MB + $rss_mb" | bc)
+done <<< "$PROCS"
+
+# Validation
+BACKEND_PASS=$(echo "$BACKEND_MB <= $BACKEND_MAX" | bc)
+WEBVIEW_PASS=$(echo "$WEBVIEW_MB <= $WEBVIEW_MAX" | bc)
+TOTAL_PASS=$(echo "$TOTAL_MB <= $TOTAL_MAX" | bc)
+
+ALL_PASS=1
+[ "$BACKEND_PASS" -eq 0 ] && ALL_PASS=0
+[ "$WEBVIEW_PASS" -eq 0 ] && ALL_PASS=0
+[ "$TOTAL_PASS" -eq 0 ] && ALL_PASS=0
+
+# Output
+if [ -n "$OUTPUT_JSON" ]; then
+  cat <<EOF
+{
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "verdict": $([ "$ALL_PASS" -eq 1 ] && echo '"PASS"' || echo '"FAIL"'),
+  "processes": {
+    "backend": {"memory_mb": $BACKEND_MB, "threshold_mb": $BACKEND_MAX, "pass": $([ "$BACKEND_PASS" -eq 1 ] && echo "true" || echo "false")},
+    "webview": {"memory_mb": $WEBVIEW_MB, "threshold_mb": $WEBVIEW_MAX, "pass": $([ "$WEBVIEW_PASS" -eq 1 ] && echo "true" || echo "false")},
+    "graphics": {"memory_mb": $GRAPHICS_MB},
+    "networking": {"memory_mb": $NETWORKING_MB}
+  },
+  "total": {"memory_mb": $TOTAL_MB, "threshold_mb": $TOTAL_MAX, "pass": $([ "$TOTAL_PASS" -eq 1 ] && echo "true" || echo "false")}
+}
+EOF
+else
+  echo "=== Kattle Memory Validation ==="
+  echo ""
+  echo "Processes:"
+  while IFS='|' read -r pid type name rss_mb; do
+    [ -z "$pid" ] && continue
+    printf "  %-25s %8s MB  (PID: %s)\n" "$name" "$rss_mb" "$pid"
+  done <<< "$PROCS"
+  echo ""
+  echo "Summary:"
+  printf "  %-20s %8s MB / %s MB  %s\n" "Go Backend" "$BACKEND_MB" "$BACKEND_MAX" "$([ "$BACKEND_PASS" -eq 1 ] && echo "PASS" || echo "FAIL")"
+  printf "  %-20s %8s MB / %s MB  %s\n" "WebView" "$WEBVIEW_MB" "$WEBVIEW_MAX" "$([ "$WEBVIEW_PASS" -eq 1 ] && echo "PASS" || echo "FAIL")"
+  printf "  %-20s %8s MB / %s MB  %s\n" "TOTAL" "$TOTAL_MB" "$TOTAL_MAX" "$([ "$TOTAL_PASS" -eq 1 ] && echo "PASS" || echo "FAIL")"
+  echo ""
+  if [ "$ALL_PASS" -eq 1 ]; then
+    echo "VERDICT: PASS"
+  else
+    echo "VERDICT: FAIL"
+  fi
+fi
+
+exit $([ "$ALL_PASS" -eq 1 ] && echo 0 || echo 1)

--- a/.claude/skills/memory-capture/SKILL.md
+++ b/.claude/skills/memory-capture/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: memory-capture
+description: Memory profile snapshot capture and baseline comparison. Use for verification after memory optimization.
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# Memory Capture Skill
+
+This skill provides tools for capturing memory profile snapshots and comparing them against baseline profiles to verify memory optimization efforts.
+
+## Prerequisites
+
+**IMPORTANT**: pprof server requires `KATTLE_DEBUG=1` environment variable:
+
+```bash
+# Start the application with debug mode enabled
+KATTLE_DEBUG=1 wails dev
+```
+
+Verify pprof server is running:
+```bash
+curl -s http://localhost:6060/debug/pprof/ > /dev/null && echo "pprof OK" || echo "pprof NOT available"
+```
+
+**Note**: Run all commands from project root directory where `baseline_heap.pb.gz` and `baseline_goroutine.txt` are located.
+
+## Capabilities
+
+### 1. Heap Profile Capture
+
+Captures the current heap memory profile:
+
+```bash
+curl -s -o /tmp/current_heap.pb.gz http://localhost:6060/debug/pprof/heap
+```
+
+This generates a compressed protobuf format heap profile that can be analyzed with `go tool pprof`.
+
+### 2. Goroutine Profile Capture
+
+Captures the current goroutine information:
+
+```bash
+curl -s http://localhost:6060/debug/pprof/goroutine?debug=1 > /tmp/current_goroutine.txt
+```
+
+This captures goroutine stack traces in text format for easy inspection.
+
+### 3. Compare with Baseline
+
+#### Heap Comparison
+
+Compare current heap profile against baseline using pprof's diff mode:
+
+```bash
+go tool pprof -diff_base=baseline_heap.pb.gz -top /tmp/current_heap.pb.gz
+```
+
+This shows the differences in memory allocation between the baseline and current profiles.
+
+#### Goroutine Count Comparison
+
+Extract and compare actual goroutine counts (not line counts):
+
+```bash
+# Extract goroutine count from first line "goroutine N [...]"
+head -1 baseline_goroutine.txt | grep -oE 'goroutine [0-9]+' | cut -d' ' -f2
+head -1 /tmp/current_goroutine.txt | grep -oE 'goroutine [0-9]+' | cut -d' ' -f2
+```
+
+Or count total goroutines in the profile:
+```bash
+grep -c '^goroutine' baseline_goroutine.txt
+grep -c '^goroutine' /tmp/current_goroutine.txt
+```
+
+### 4. Update Baseline (if improved)
+
+When optimization is verified and improvements are confirmed:
+
+```bash
+cp /tmp/current_heap.pb.gz baseline_heap.pb.gz
+cp /tmp/current_goroutine.txt baseline_goroutine.txt
+```
+
+This updates the baseline profiles for future comparisons.
+
+## Usage
+
+Use the provided `capture-profile.sh` script to capture both profiles in one command:
+
+```bash
+./scripts/capture-profile.sh [PORT]
+```
+
+Default port is 6060 if not specified.
+
+## Workflow
+
+1. Capture baseline profiles before optimization
+2. Implement memory optimizations
+3. Capture new profiles after optimization
+4. Compare using the tools above
+5. If improvements verified, update baseline
+6. Continue iterating or celebrate success

--- a/.claude/skills/memory-capture/scripts/capture-profile.sh
+++ b/.claude/skills/memory-capture/scripts/capture-profile.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Memory profile capture script for kattle
+# Usage: capture-profile.sh [PORT]
+# Requires: KATTLE_DEBUG=1 wails dev (or similar) to enable pprof server
+
+set -e
+
+PORT="${1:-6060}"
+
+# Check if pprof server is available
+if ! curl -s "http://localhost:$PORT/debug/pprof/" > /dev/null 2>&1; then
+    echo "Error: pprof server not available at localhost:$PORT"
+    echo "Ensure the app is running with KATTLE_DEBUG=1"
+    exit 1
+fi
+
+curl -s -o /tmp/current_heap.pb.gz "http://localhost:$PORT/debug/pprof/heap"
+curl -s "http://localhost:$PORT/debug/pprof/goroutine?debug=1" > /tmp/current_goroutine.txt
+
+# Show goroutine count
+GOROUTINE_COUNT=$(grep -c '^goroutine' /tmp/current_goroutine.txt || echo "0")
+echo "Captured: /tmp/current_heap.pb.gz, /tmp/current_goroutine.txt (goroutines: $GOROUTINE_COUNT)"

--- a/.claude/skills/memory-profiling/SKILL.md
+++ b/.claude/skills/memory-profiling/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: memory-profiling
+description: Go application memory profiling and analysis. Use when investigating memory leaks or high memory usage.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash, Read, Grep
+---
+
+# Memory Profiling Skill
+
+Investigate and analyze Go application memory usage through heap profiling and comparative analysis.
+
+## Prerequisites
+
+**IMPORTANT**: pprof server requires `KATTLE_DEBUG=1` environment variable:
+
+```bash
+# Start the application with debug mode enabled
+KATTLE_DEBUG=1 wails dev
+```
+
+Verify pprof server is running:
+```bash
+curl -s http://localhost:6060/debug/pprof/ > /dev/null && echo "pprof OK" || echo "pprof NOT available"
+```
+
+## Current State Check
+
+Before profiling, establish the current memory baseline:
+
+```bash
+ps aux | grep -E "(PID|kattle|gui)" | head -20
+```
+
+Verify baseline profile exists (from project root):
+```bash
+ls -lh baseline_heap.pb.gz 2>/dev/null || echo "No baseline found"
+```
+
+## Heap Profile Collection
+
+Collect a heap profile from the running application:
+
+```bash
+curl -o /tmp/heap.pb.gz http://localhost:6060/debug/pprof/heap
+```
+
+Verify collection was successful:
+```bash
+ls -lh /tmp/heap.pb.gz
+```
+
+**Alternative**: The app provides `DumpMemory(label)` function which saves labeled dumps to `~/kattle-dumps/`:
+- Format: `heap_<timestamp>_<seq>_<label>.pb.gz`
+- Location: `~/kattle-dumps/`
+
+## Analysis Commands
+
+### Top 10 Memory Allocators
+
+Get the most significant memory allocators:
+
+```bash
+go tool pprof -top /tmp/heap.pb.gz | head -15
+```
+
+### Differential Analysis (vs Baseline)
+
+Compare current heap profile against a known baseline:
+
+```bash
+go tool pprof -diff_base=baseline_heap.pb.gz -top /tmp/heap.pb.gz
+```
+
+Or use the helper script:
+```bash
+bash /Users/hansuk.hong/P/kattle/.claude/skills/memory-profiling/scripts/compare-heap.sh [baseline_path] [current_path]
+```
+
+### Interactive Investigation
+
+For deeper analysis, use interactive mode:
+
+```bash
+go tool pprof /tmp/heap.pb.gz
+# Then use commands like: top, list <function>, alloc_space, alloc_objects
+```
+
+## Reporting Format
+
+When analyzing memory profiles, report:
+
+1. **Top 10 Allocators**: List of functions responsible for largest allocations
+2. **Delta from Baseline**: Increase/decrease in allocation patterns since baseline
+3. **Suspect Areas**: Functions or packages with unexplained growth
+4. **Memory Metrics**:
+   - Total inuse_space (bytes)
+   - Total alloc_objects (count)
+   - Per-function percentages of total heap
+
+### Example Report Structure
+
+```
+Memory Profile Analysis Report
+==============================
+
+Top 10 Allocators (Current):
+1. package.function - X.XGB (XX%)
+2. package.function - X.XGB (XX%)
+...
+
+Changes vs Baseline:
+- package.function: +X.XGB (new allocation)
+- package.function: -X.XGB (reduction)
+
+Suspect Areas:
+- package.function: Excessive allocation growth
+- Recommendations for investigation
+```
+
+## Usage Workflow
+
+1. Establish baseline: Collect heap profile when application is in healthy state
+2. Run application under load or over time
+3. Collect current heap profile
+4. Compare using differential analysis
+5. Investigate top allocators and changes
+6. Identify memory leaks or optimization opportunities

--- a/.claude/skills/memory-profiling/scripts/compare-heap.sh
+++ b/.claude/skills/memory-profiling/scripts/compare-heap.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Memory profiling comparison script for kattle
+# Usage: compare-heap.sh [baseline_path] [current_path]
+# Note: Run from project root where baseline_heap.pb.gz is located
+
+set -e
+
+BASELINE="${1:-baseline_heap.pb.gz}"
+CURRENT="${2:-/tmp/current_heap.pb.gz}"
+
+# Validate inputs
+if [ ! -f "$BASELINE" ]; then
+    echo "Error: Baseline file not found: $BASELINE"
+    echo "Run from project root or specify full path"
+    exit 1
+fi
+
+if [ ! -f "$CURRENT" ]; then
+    echo "Error: Current heap profile not found: $CURRENT"
+    echo "Capture a profile first using: curl -o $CURRENT http://localhost:6060/debug/pprof/heap"
+    exit 1
+fi
+
+echo "Memory Profile Comparison"
+echo "=========================="
+echo "Baseline: $BASELINE ($(ls -lh "$BASELINE" | awk '{print $5}'))"
+echo "Current:  $CURRENT ($(ls -lh "$CURRENT" | awk '{print $5}'))"
+echo ""
+echo "Differential Analysis (Delta):"
+echo "------------------------------"
+
+go tool pprof -diff_base="$BASELINE" -top "$CURRENT"

--- a/.claude/skills/react-quality/SKILL.md
+++ b/.claude/skills/react-quality/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: react-quality
+description: React/TypeScript code quality rules for kattle frontend. Apply when writing or reviewing frontend code.
+disable-model-invocation: true
+user-invocable: false
+allowed-tools: Read, Edit, Write, Grep, Glob
+---
+
+# React/TypeScript Code Quality Guidelines
+
+## Overview
+This skill enforces critical code quality standards for React and TypeScript in the kattle frontend. Apply these rules rigorously when writing, modifying, or reviewing components.
+
+## Essential Rules
+
+### 1. No Type Assertions (`as`)
+**Rule:** Use explicit type declarations instead of type assertions.
+
+**Why:** Type assertions bypass TypeScript's type checking and hide potential bugs.
+
+**Bad:**
+```typescript
+const user = data as User;
+const count = value as number;
+```
+
+**Good:**
+```typescript
+const user: User = parseUserData(data);
+const count: number = parseInt(value, 10);
+```
+
+---
+
+### 2. No Unused Imports
+**Rule:** Remove all unused imports from files.
+
+**Why:** Clutters code, increases bundle size, and creates maintenance confusion.
+
+**Check:** TypeScript will flag unused imports. Remove them during code review.
+
+---
+
+### 3. Safe Array Access
+**Rule:** Always check for undefined before accessing array elements or object properties.
+
+**Why:** Prevents runtime crashes from accessing undefined values.
+
+**Bad:**
+```typescript
+const item = items[0];
+const name = user.profile.name; // what if user or profile is undefined?
+```
+
+**Good:**
+```typescript
+const item = items?.[0];
+const name = user?.profile?.name ?? 'Unknown';
+```
+
+---
+
+### 4. Explicit Type Annotations for Complex Structures
+**Rule:** Add type annotations for function parameters, return types, and complex state.
+
+**Why:** Makes code self-documenting and catches type errors early.
+
+**Bad:**
+```typescript
+function processData(data) {
+  const result = { ...data };
+  return result;
+}
+
+const [state, setState] = useState({});
+```
+
+**Good:**
+```typescript
+interface ProcessedData {
+  id: string;
+  timestamp: Date;
+  value: number;
+}
+
+function processData(data: unknown): ProcessedData {
+  const result: ProcessedData = { ...data as ProcessedData };
+  return result;
+}
+
+interface AppState {
+  user: User | null;
+  isLoading: boolean;
+}
+
+const [state, setState] = useState<AppState>({
+  user: null,
+  isLoading: false,
+});
+```
+
+---
+
+### 5. React Element Keys - Unique and Stable
+**Rule:** Always provide stable, unique keys in lists. Never use array indices.
+
+**Why:** React uses keys to match elements across renders. Unstable keys cause state loss and bugs.
+
+**Bad:**
+```typescript
+{items.map((item, index) => (
+  <div key={index}>{item.name}</div>
+))}
+```
+
+**Good:**
+```typescript
+{items.map((item) => (
+  <div key={item.id}>{item.name}</div>
+))}
+```
+
+---
+
+### 6. useCallback for Event Handlers
+**Rule:** Wrap event handler functions in `useCallback` to prevent unnecessary re-renders of child components.
+
+**Why:** Prevents children from re-rendering when parent updates, improving performance.
+
+**Bad:**
+```typescript
+const handleClick = () => {
+  dispatch(updateState());
+};
+
+return <Button onClick={handleClick} />;
+```
+
+**Good:**
+```typescript
+const handleClick = useCallback(() => {
+  dispatch(updateState());
+}, [dispatch]);
+
+return <Button onClick={handleClick} />;
+```
+
+---
+
+### 7. Functional State Updates
+**Rule:** Use the function form of `setState` when the new state depends on previous state.
+
+**Why:** Ensures you're always working with the latest state, preventing race conditions.
+
+**Bad:**
+```typescript
+const [count, setCount] = useState(0);
+const increment = () => setCount(count + 1);
+```
+
+**Good:**
+```typescript
+const [count, setCount] = useState(0);
+const increment = useCallback(() => {
+  setCount((prev) => prev + 1);
+}, []);
+```
+
+---
+
+### 8. Complete Dependency Arrays
+**Rule:** Always include all external values used in hooks (useEffect, useCallback, useMemo) in their dependency arrays.
+
+**Why:** Missing dependencies cause stale closures and bugs that are hard to debug.
+
+**Bad:**
+```typescript
+useEffect(() => {
+  console.log(userId); // userId is missing from deps!
+  fetchUser();
+}, []);
+```
+
+**Good:**
+```typescript
+useEffect(() => {
+  console.log(userId);
+  fetchUser();
+}, [userId]);
+```
+
+---
+
+### 9. Component Decomposition
+**Rule:** Split components when they exceed 300 lines. Extract sections into separate components.
+
+**Why:** Large components are hard to understand, test, and maintain.
+
+**Indicators of a "fat" component:**
+- Multiple independent sections with their own state
+- Deeply nested JSX
+- Multiple responsibilities (data fetching, UI rendering, business logic)
+
+**Action:** Extract into smaller, focused components with clear interfaces.
+
+---
+
+### 10. Props and State Typing
+**Rule:** Define explicit interfaces for component props. Never use `any` or `unknown` without narrowing.
+
+**Why:** Makes component contracts clear and catches prop errors early.
+
+**Bad:**
+```typescript
+function Card(props: any) {
+  return <div>{props.content}</div>;
+}
+```
+
+**Good:**
+```typescript
+interface CardProps {
+  content: string;
+  variant?: 'default' | 'outlined';
+  onClick?: (id: string) => void;
+}
+
+function Card({ content, variant = 'default', onClick }: CardProps) {
+  return <div onClick={() => onClick?.(content)}>{content}</div>;
+}
+```
+
+---
+
+## Quick Checklist
+
+Before submitting code or approving a PR, verify:
+
+- [ ] No `as` type assertions
+- [ ] No unused imports
+- [ ] All array/object access is safe (using optional chaining or checks)
+- [ ] Function parameters and return types have explicit annotations
+- [ ] Component props defined in a clear interface
+- [ ] List items have stable, unique `key` props
+- [ ] Event handlers wrapped in `useCallback` (if passed to children)
+- [ ] State updates use functional form when dependent on previous state
+- [ ] All hook dependencies are complete and correct
+- [ ] Components are decomposed (max 300 lines)
+- [ ] No `any` types without narrowing
+
+---
+
+## When to Apply This Skill
+
+Apply these rules when:
+- Writing new React components
+- Reviewing pull requests with TypeScript/React changes
+- Refactoring existing components
+- Debugging type-related issues
+
+Prioritize rules 1-8 as they prevent the most common and serious bugs.

--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: test-runner
+description: Run Go and frontend tests for kattle project. Use after code changes to verify correctness.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash, Read
+---
+
+# Test Runner Skill
+
+This skill provides commands and workflows for running tests in the kattle project across Go backend and React frontend codebases.
+
+## Go Tests
+
+Run backend tests using the Go test runner:
+
+```bash
+# All tests
+go test ./...
+
+# Specific package
+go test ./internal/kube/...
+
+# With verbose output
+go test -v ./...
+
+# With race detection
+go test -race ./...
+
+# With coverage
+go test -cover ./...
+```
+
+### Options Reference
+- `-v`: Verbose output with individual test results
+- `-race`: Enable race condition detection
+- `-cover`: Display coverage percentage
+- `-timeout`: Set timeout (e.g., `-timeout 30s`)
+- `-run`: Run specific tests matching pattern (e.g., `-run TestName`)
+
+## Frontend Tests
+
+Run frontend tests using npm in the React project:
+
+```bash
+# Run all tests (single run)
+npm --prefix cmd/gui/frontend run test:run
+
+# Watch mode (re-run on file changes)
+npm --prefix cmd/gui/frontend run test
+
+# With coverage report
+npm --prefix cmd/gui/frontend run test:run -- --coverage
+```
+
+### Frontend Test Scripts
+- `test`: Run tests in watch mode for development
+- `test:run`: Single test run (useful for CI/CD)
+- Coverage reports are generated in `coverage/` directory
+
+## Combined Test Run
+
+Run both Go and frontend tests in sequence:
+
+```bash
+# Quick validation (both suites)
+go test ./... && npm --prefix cmd/gui/frontend run test:run
+```
+
+This validates the entire codebase before committing or creating a PR.
+
+## Report Format
+
+After running tests, expect output with:
+
+- **PASS/FAIL status**: Clear indication of test suite success or failure
+- **Failed test details**: Names and error messages for any failing tests
+- **Coverage summary**: If coverage flags are used, percentage of code covered
+- **Execution time**: Total time taken to run test suite
+
+## Recommended Test Workflow
+
+1. **After making changes**: Run targeted tests first
+   ```bash
+   go test ./internal/kube/...
+   ```
+
+2. **Before committing**: Run full test suites
+   ```bash
+   go test ./... && npm --prefix cmd/gui/frontend run test:run
+   ```
+
+3. **For pull requests**: Include coverage results
+   ```bash
+   go test -cover ./... 
+   npm --prefix cmd/gui/frontend run test:run -- --coverage
+   ```

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ assets/releases/
 *.pb.gz
 *_goroutine.txt
 *_heap.*
+
+./claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,421 @@
-read this @planning/*.spec.md and interview me in detail using the AskUserQuestionTool about literally anything: technical implementation, UI & UX, concerns, tradeoffs, etc. but make sure the questions are not obvious
+# Kattle
 
-be very in-depth and continue interviewing me continually until it's complete, then write the spec to the file
+## Project Overview
 
-## Constraints
+Kubernetes 탐색 도구 - CLI TUI + Desktop GUI
+- Go 백엔드 + React 프론트엔드 (Wails)
+- TUI (cmd/kupid): **Deprecated** - 유지보수만, 신규 개발 없음
+- **주요 타겟**: Desktop GUI (cmd/gui)
 
-- cannot use `cd` in my shell
-- ask about running debug app, `wails dev` is running in the background by myself
+## Architecture
+
+```
+cmd/kupid/          # CLI TUI (Bubble Tea) - DEPRECATED
+cmd/gui/            # Desktop GUI (Wails + React) - PRIMARY TARGET
+internal/kube/      # Kubernetes 클라이언트 (메모리 최적화 중점)
+internal/ui/        # TUI 컴포넌트
+website/            # 문서 사이트 (Astro)
+```
+
+## Current Focus
+
+메모리 최적화 (Go 백엔드):
+- KeyOnlyStore: 메타데이터만 저장하는 informer store
+- FieldStore: 필요한 필드만 추출 저장
+- String interning: 중복 문자열 최소화
+
+프로파일링 베이스라인:
+- `baseline_heap.pb.gz` - 힙 메모리 기준점
+- `baseline_goroutine.txt` - 고루틴 수 기준점
+
+---
+
+## Session Prerequisites
+
+장기 자율 세션 시작 전 확인:
+
+```bash
+# 1. wails dev 실행 중 (바인딩 자동 갱신, 핫 리로드)
+pgrep -f "wails dev" || echo "Start: wails dev (background)"
+
+# 2. pprof 엔드포인트 접근 가능 (메모리 프로파일링)
+curl -s http://localhost:6060/debug/pprof/ > /dev/null && echo "pprof OK"
+
+# 3. Vite dev server (Playwright 접근용, 기본 localhost:5173)
+curl -s http://localhost:5173/ > /dev/null && echo "Vite OK"
+```
+
+Manager는 세션 시작 시 이 조건들을 확인하고, 누락 시 사용자에게 알림.
+
+### 자율 실행 권한 설정
+
+자율 루프가 매 명령마다 중단되지 않으려면 세션 시작 시 다음 권한을 승인:
+
+```
+Allowed prompts (ExitPlanMode 또는 첫 실행 시 설정):
+- Bash: run go tests
+- Bash: run npm/vitest tests
+- Bash: capture memory profiles (curl, pprof)
+- Bash: git operations (status, add, commit)
+- Edit/Write: modify source files in internal/, cmd/
+```
+
+또는 CLI 옵션 사용: `claude --allowedTools 'Bash(run tests),Edit(*)'`
+
+**주의**: `--dangerously-skip-permissions`는 보안상 권장하지 않음.
+
+---
+
+## Scenario Input (세션별)
+
+세션 시작 시 사용자가 관측/검증 시나리오를 제공:
+
+```yaml
+# 예시: 메모리 관측 시나리오
+scenario:
+  type: memory-observation
+  context: prodlive-gs-koreacentral
+  resource: pods
+
+  # 메모리 목표
+  memory_targets:
+    current_baseline: 450MB          # 현재 베이스라인 (참고용)
+    target_baseline: 200MB           # 달성 목표
+    max_threshold: 300MB             # 이 이상이면 FAIL
+    goroutine_limit: 100             # 고루틴 수 상한
+
+  checkpoints:
+    - name: initial-load
+      trigger: "리소스 목록 요청 직후"
+      capture: [heap, goroutine]
+    - name: after-load
+      trigger: "로딩 완료 후 안정화 (5s)"
+      capture: [heap, goroutine]
+
+  # 검증 결과 판정
+  verdict:
+    pass: "heap <= max_threshold AND goroutines <= goroutine_limit"
+    improve_baseline: "heap < current_baseline"
+```
+
+```yaml
+# 예시: 기능 구현 시나리오
+scenario:
+  type: feature-implementation
+  spec: planning/260105-optimize-go-mem.spec.md
+  verification_mode: per-commit
+
+  # 메모리 회귀 방지
+  memory_guard:
+    max_regression: 10%              # 베이스라인 대비 최대 허용 증가
+    baseline_file: baseline_heap.pb.gz
+```
+
+Manager는 시나리오를 파싱하여:
+1. 필요한 subagent 결정
+2. Playwright로 UI 자동화 (memory-observation인 경우)
+3. 체크포인트에서 memory-capture 실행
+4. 결과 수집 및 보고
+
+---
+
+## Autonomous Loop Workflow
+
+### Architecture Constraint
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      MANAGER (Main Session)                 │
+│                                                             │
+│   • 모든 서브에이전트를 직접 spawn/관리                       │
+│   • 서브에이전트는 서브에이전트를 spawn 불가 (2단계 제한)      │
+│   • 작업 규모 판단 → 분할 여부 결정                          │
+└─────────────────────────────────────────────────────────────┘
+         │
+         │ spawn (직접 관리)
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      SUBAGENTS (Flat)                       │
+│                                                             │
+│   worker ─── reviewer ─── verifier ─── analyzer             │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Main Loop
+
+```
+┌─────────────────┐
+│   TASK INPUT    │
+│  (spec, issue)  │
+└────────┬────────┘
+         │
+         ▼
+┌──────────────────────────────────────┐
+│           1. ASSESS                  │
+│                                      │
+│  Q: 작업이 충분히 작은가?             │
+│                                      │
+│  YES → 단일 작업으로 진행             │
+│  NO  → 커밋 단위로 분할              │
+│        (subtask = 1 commit)          │
+└──────────────────┬───────────────────┘
+                   │
+         ┌─────────┴─────────┐
+         │                   │
+         ▼                   ▼
+   ┌───────────┐      ┌─────────────────────────┐
+   │  SMALL    │      │         LARGE           │
+   │  단일작업  │      │   Subtask 1 ← commit 1  │
+   └─────┬─────┘      │   Subtask 2 ← commit 2  │
+         │            │   Subtask N ← commit N  │
+         │            └───────────┬─────────────┘
+         │                        │
+         └────────────┬───────────┘
+                      │
+                      ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    2. EXECUTE (per subtask)                 │
+│                                                             │
+│   Manager spawns team for this subtask:                     │
+│                                                             │
+│   ┌──────────┐    ┌──────────┐    ┌──────────┐             │
+│   │  WORKER  │───▶│ REVIEWER │───▶│ VERIFIER │             │
+│   │ (code)   │    │ (review) │    │ (test+mem)│             │
+│   └──────────┘    └──────────┘    └──────────┘             │
+│                                                             │
+│   • Worker: go-worker 또는 frontend-worker                  │
+│   • Reviewer: 필요시 참여 (복잡한 변경)                      │
+│   • Verifier: 테스트 + 메모리 검증                          │
+│                                                             │
+│   Large task → 여러 subtask 팀 병렬 가능:                   │
+│   [Subtask1: worker→verifier] ∥ [Subtask2: worker→verifier] │
+│                                                             │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    3. VERIFY                                │
+│                                                             │
+│   ┌─────────────────────────────────────────┐               │
+│   │ Verification Mode (configurable)        │               │
+│   ├─────────────────────────────────────────┤               │
+│   │ per-commit  │ 매 커밋마다 (현재 기본값)  │               │
+│   │ per-branch  │ 브랜치 완료 시            │               │
+│   │ on-demand   │ 사용자 요청 시            │               │
+│   └─────────────────────────────────────────┘               │
+│                                                             │
+│   Verifier 실행:                                            │
+│   • go test ./...                                           │
+│   • npm test:run                                            │
+│   • memory profile vs baseline                              │
+│                                                             │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                   ┌──────┴──────┐
+                   ▼             ▼
+             ┌────────┐    ┌────────┐
+             │  PASS  │    │  FAIL  │
+             └───┬────┘    └───┬────┘
+                 │             │
+                 │             ▼
+                 │      ┌─────────────┐
+                 │      │  DIAGNOSE   │
+                 │      │  (Manager)  │
+                 │      └──────┬──────┘
+                 │             │
+                 │             │ retry < 3?
+                 │             ├─── YES ──▶ (back to EXECUTE)
+                 │             │
+                 │             │ NO
+                 │             ▼
+                 │      ┌─────────────┐
+                 │      │  ESCALATE   │──▶ User
+                 │      └─────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    4. COMMIT                                │
+│                                                             │
+│   • Stage changes                                           │
+│   • Commit (1 subtask = 1 commit)                          │
+│   • Update baseline (if memory improved)                    │
+│                                                             │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+                 ┌─────────────────┐
+                 │ More subtasks?  │
+                 └────────┬────────┘
+                          │
+                  YES     │     NO
+                    ◀─────┴─────▶
+                    │           │
+           (next subtask)       ▼
+                         ┌─────────────┐
+                         │  FINALIZE   │
+                         │  • Summary  │
+                         │  • PR       │
+                         └──────┬──────┘
+                                │
+                                ▼
+                  ┌───────────────────────────┐
+                  │  POST-ANALYSIS (선택)     │
+                  │                           │
+                  │  feature-dev:code-explorer│
+                  │  • 변경사항 아키텍처 분석  │
+                  │  • 영향 범위 문서화        │
+                  │  • 기술 부채 식별          │
+                  └───────────────────────────┘
+```
+
+### Task Sizing Decision
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    MANAGER의 판단 기준                       │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  충분히 작은 작업 (분할 안 함):                              │
+│  • 단일 파일 또는 밀접한 2-3개 파일 수정                     │
+│  • 하나의 논리적 변경 (single concern)                       │
+│  • 예: 버그 수정, 작은 리팩토링, 단일 함수 추가              │
+│                                                             │
+│  분할이 필요한 작업:                                         │
+│  • 여러 독립적 변경이 포함됨                                 │
+│  • 각 변경이 독립적으로 테스트/커밋 가능                     │
+│  • 예: 여러 모듈에 걸친 기능, 대규모 리팩토링                │
+│                                                             │
+│  분할 단위 = 커밋 단위 = Subtask                            │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Team Composition per Subtask
+
+| Subtask 특성 | Worker | Reviewer | Verifier |
+|-------------|--------|----------|----------|
+| Go only | go-worker | (선택) | verifier |
+| Frontend only | frontend-worker | (선택) | verifier |
+| Go + Frontend | go-worker, frontend-worker | (선택) | verifier |
+| 복잡한 로직 | worker | reviewer | verifier |
+| 메모리 관련 | worker | - | verifier + memory-analyzer |
+
+**Reviewer 참여 조건**: 복잡한 알고리즘, 아키텍처 변경, 동시성 코드
+
+### Exit Conditions
+
+- ✅ 모든 subtask 완료 + 검증 통과
+- ⚠️ 재시도 3회 초과 → 사용자 에스컬레이션
+- 🛑 사용자 중단 요청
+
+---
+
+## Subagent Coordination
+
+### 커스텀 에이전트 (kattle:)
+
+| Agent | 용도 | Skills | Tech Stack | Model |
+|-------|------|--------|------------|-------|
+| `kattle:go-worker` | Go 코드 수정 | go-quality | Go, client-go, informer, pprof | opus |
+| `kattle:frontend-worker` | React/TS 수정 | react-quality | React, TypeScript, Wails, Vite, Tailwind, Radix | opus |
+| `kattle:memory-analyzer` | 메모리 프로파일 분석 | memory-profiling, macos-memory | Go pprof, macOS leaks/heap/vmmap | opus |
+| `kattle:verifier` | 테스트 + 메모리 검증 | test-runner, memory-capture | Go test, Vitest, pprof, Playwright | opus |
+| `kattle:reviewer` | 프로젝트 규칙 리뷰 | go-quality, react-quality | Go, React, TypeScript, Wails | opus |
+
+#### Agent Descriptions (에이전트 생성 시 사용)
+
+```
+kattle:go-worker
+Modifies Go code in internal/kube and cmd packages for the kattle Kubernetes explorer, focusing on memory-efficient patterns using client-go informers, KeyOnlyStore, and FieldStore with strict adherence to project error handling and concurrency standards.
+
+kattle:frontend-worker
+Modifies React/TypeScript frontend code in cmd/gui/frontend for the kattle Wails desktop app, implementing virtualized tables, real-time Kubernetes resource updates via Wails IPC events, and Radix UI components with strict type safety and no type assertions.
+
+kattle:memory-analyzer
+Analyzes Go application memory profiles using pprof and macOS native tools (leaks, heap, vmmap) to identify memory leaks, excessive allocations, and goroutine leaks, comparing against baseline profiles and recommending specific optimization strategies.
+
+kattle:verifier
+Runs Go and frontend tests, captures memory profiles at specified checkpoints, compares heap/goroutine counts against baselines and thresholds, and uses Playwright to automate UI scenarios for memory observation during context switching and resource loading.
+
+kattle:reviewer
+Reviews code changes against kattle project conventions (CODE_QUALITY_GO.md, CODE_QUALITY.md), focusing on memory optimization patterns, proper error wrapping, safe concurrency, type safety, and architectural consistency with existing codebase patterns.
+```
+
+### 빌트인 에이전트 (subagent_type)
+
+| subagent_type | 용도 | 워크플로 단계 |
+|---------------|------|--------------|
+| `Explore` | 빠른 코드 탐색 | ASSESS (파일/심볼 검색) |
+| `feature-dev:code-reviewer` | 범용 코드 리뷰 | EXECUTE 후 (버그/보안 체크) |
+| `feature-dev:code-explorer` | 깊은 아키텍처 분석 | POST-ANALYSIS (변경 영향 분석) |
+
+### 리뷰어 사용 구분
+
+| 상황 | 사용할 에이전트 |
+|------|----------------|
+| 메모리 최적화 관련 변경 | `kattle:reviewer` (프로젝트 규칙 적용) |
+| 일반 버그/로직/보안 | `feature-dev:code-reviewer` (범용) |
+| 복잡한 아키텍처 변경 | 둘 다 순차 실행 |
+
+### Task 호출 방식
+
+**커스텀 에이전트 호출**: `.claude/agents/` 디렉토리에 정의된 에이전트는 이름으로 호출:
+
+```python
+# 커스텀 에이전트 (kattle:*)
+Task(subagent_type="kattle:go-worker", prompt="...")
+
+# 빌트인 에이전트
+Task(subagent_type="Explore", prompt="...")
+Task(subagent_type="feature-dev:code-reviewer", prompt="...")
+```
+
+**주의**: 커스텀 에이전트가 인식되지 않으면 `general-purpose`로 폴백되며, 에이전트 본문의 지침이 적용되지 않을 수 있음. 이 경우 prompt에 필요한 컨텍스트를 직접 포함.
+
+### Manager Spawn Examples
+
+```python
+# 단일 작업 (small task)
+Task(subagent_type="kattle:go-worker", prompt="Fix nil check in client.go:142")
+Task(subagent_type="kattle:verifier", prompt="Run tests and verify memory")
+
+# 복잡한 단일 작업 (with review)
+Task(subagent_type="kattle:go-worker", prompt="Implement new caching logic")
+Task(subagent_type="kattle:reviewer", prompt="Review the caching implementation")
+Task(subagent_type="kattle:verifier", prompt="Run tests and memory check")
+
+# 대규모 작업 - Subtask 병렬 실행 (단일 메시지에서)
+[
+  Task(subagent_type="kattle:go-worker", prompt="Subtask 1: Refactor store interface"),
+  Task(subagent_type="kattle:frontend-worker", prompt="Subtask 2: Update UI bindings"),
+]
+# (완료 후 각각 verify)
+Task(subagent_type="kattle:verifier", prompt="Verify subtask 1")
+Task(subagent_type="kattle:verifier", prompt="Verify subtask 2")
+```
+
+---
+
+## Key Files
+
+- `planning/*.spec.md` - 기능 스펙 문서
+- `CODE_QUALITY_GO.md` - Go 코드 품질 가이드라인
+- `cmd/gui/frontend/CODE_QUALITY.md` - React 코드 품질 가이드라인
+
+## Commands
+
+```bash
+# Build & Run
+wails dev                           # Development mode (GUI)
+go run ./cmd/kupid                  # TUI mode
+
+# Test
+go test ./...                       # Go tests
+npm --prefix cmd/gui/frontend test:run  # Frontend tests
+
+# Profile
+curl -o heap.pb.gz http://localhost:6060/debug/pprof/heap
+go tool pprof -top heap.pb.gz
+go tool pprof -diff_base=baseline_heap.pb.gz heap.pb.gz
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+read this @planning/*.spec.md and interview me in detail using the AskUserQuestionTool about literally anything: technical implementation, UI & UX, concerns, tradeoffs, etc. but make sure the questions are not obvious
+
+be very in-depth and continue interviewing me continually until it's complete, then write the spec to the file
+
+## Constraints
+
+- cannot use `cd` in my shell
+- ask about running debug app, `wails dev` is running in the background by myself

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -23,9 +24,9 @@ import (
 
 // logMemoryStats logs current goroutine count and event metrics for debugging
 func logMemoryStats(label string) {
-	emitted, dropped := kube.GetEventMetrics()
-	log.Printf("[DEBUG] %s: goroutines=%d, events_emitted=%d, events_dropped=%d",
-		label, goruntime.NumGoroutine(), emitted, dropped)
+	emitted, dropped, synced, trySent := kube.GetEventMetrics()
+	log.Printf("[DEBUG] %s: goroutines=%d, events_emitted=%d, events_dropped=%d, sync_processed=%d, trySend_called=%d",
+		label, goruntime.NumGoroutine(), emitted, dropped, synced, trySent)
 }
 
 // App struct
@@ -285,17 +286,20 @@ func (a *App) GetNodeTree(gvk MultiClusterGVK, contexts []string) ([]*TreeNode, 
 	}
 
 	// 2. Create node tree - use FieldStore if watches are active (memory-efficient)
+	// CRITICAL: Take a snapshot under lock to avoid race conditions with StopWatch
+	a.watchMu.RLock()
+	fs := a.fieldStore
+	a.watchMu.RUnlock()
+
 	var nodes map[string]*kube.Node
-	if a.fieldStore.Count() > 0 {
+	if fs != nil && fs.Count() > 0 {
 		// Use FieldStore's structure metadata for tree building
-		nodes = kube.CreateNodeTreeFromStore(fields, a.fieldStore, []string{})
+		nodes = kube.CreateNodeTreeFromStore(fields, fs, []string{})
 	} else {
-		// No active watch, fetch resources directly for tree building
-		objs, fetchErr := a.getResourcesWithCleanup(schemaGVK, contexts)
-		if fetchErr != nil {
-			return nil, fmt.Errorf("failed to get resources: %w", fetchErr)
-		}
-		nodes = kube.CreateNodeTree(fields, objs, []string{})
+		// No active watch or empty FieldStore - return schema-only tree
+		// IMPORTANT: Do NOT fall back to getResourcesWithCleanup() as it uses
+		// memory-heavy Inform() method. The frontend will retry when data is available.
+		nodes = kube.CreateNodeTree(fields, nil, []string{})
 	}
 
 	// 3. Convert to frontend format (remove UI state, convert to array)
@@ -331,95 +335,34 @@ func (a *App) GetDefaultSelectedPaths(gvk MultiClusterGVK, contexts []string) []
 	return nil
 }
 
-// getWatchedResources returns resources from active watch controllers if available
-func (a *App) getWatchedResources() []*unstructured.Unstructured {
+// GetResources returns resources from FieldStore (reconstructed objects)
+// Deprecated: Frontend should use GetResourcesByKeys instead for Pull Model
+// This is kept for backward compatibility only
+func (a *App) GetResources(gvk MultiClusterGVK, contexts []string) ([]map[string]any, error) {
+	// Use FieldStore to get resource data (memory-efficient)
 	a.watchMu.RLock()
-	defer a.watchMu.RUnlock()
+	fs := a.fieldStore
+	a.watchMu.RUnlock()
 
-	if len(a.controllers) == 0 {
-		return nil
+	if fs == nil {
+		return nil, nil // No active watch, return empty
 	}
 
-	var allObjs []*unstructured.Unstructured
-	for _, wc := range a.controllers {
-		objs := wc.controller.Objects()
-		allObjs = append(allObjs, objs...)
-	}
-	return allObjs
-}
+	keys := fs.List()
+	result := make([]map[string]any, 0, len(keys))
 
-// getResourcesWithCleanup fetches resources and properly cleans up controllers
-func (a *App) getResourcesWithCleanup(gvk schema.GroupVersionKind, contexts []string) ([]*unstructured.Unstructured, error) {
-	var allObjs []*unstructured.Unstructured
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	for _, contextName := range contexts {
-		wg.Add(1)
-		go func(ctx string) {
-			defer wg.Done()
-
-			gvr, err := kube.GetGVRForContext(ctx, gvk)
-			if err != nil {
-				log.Printf("Warning: failed to get GVR for %s in context %s: %v", gvk.Kind, ctx, err)
-				return
+	for _, key := range keys {
+		if obj := fs.ReconstructObject(key); obj != nil {
+			// Extract context from key (format: "context/namespace/name")
+			parts := strings.SplitN(key, "/", 2)
+			if len(parts) > 0 {
+				obj["_context"] = parts[0]
 			}
-
-			controller := kube.NewResourceControllerForContext(ctx, gvr)
-			stopCh, err := controller.Inform()
-			if err != nil {
-				log.Printf("Warning: failed to start informer for %s in context %s: %v", gvk.Kind, ctx, err)
-				return
-			}
-
-			// Get objects then immediately cleanup
-			objs := controller.Objects()
-			close(stopCh)
-			controller.Close()
-
-			mu.Lock()
-			allObjs = append(allObjs, objs...)
-			mu.Unlock()
-		}(contextName)
-	}
-
-	wg.Wait()
-	return allObjs, nil
-}
-
-// GetResources returns resources from active watch or fetches them directly
-// Deprecated: Frontend should use watch events (ADDED) for initial data instead
-// This is kept for backward compatibility and manual refresh
-func (a *App) GetResources(gvk MultiClusterGVK, contexts []string) ([]map[string]interface{}, error) {
-	// Prefer active watch data to avoid duplicate List calls
-	objs := a.getWatchedResources()
-
-	if len(objs) == 0 {
-		// No active watch, fetch with cleanup
-		schemaGVK := schema.GroupVersionKind{
-			Group:   gvk.Group,
-			Version: gvk.Version,
-			Kind:    gvk.Kind,
-		}
-		var err error
-		objs, err = a.getResourcesWithCleanup(schemaGVK, contexts)
-		if err != nil {
-			return nil, err
+			result = append(result, obj)
 		}
 	}
 
-	// Convert to frontend format with _context field
-	var allResources []map[string]interface{}
-	for _, obj := range objs {
-		resource := obj.Object
-		// _context should already be set by watch, but ensure it exists
-		if _, ok := resource["_context"]; !ok {
-			resource["_context"] = ""
-		}
-		allResources = append(allResources, resource)
-	}
-
-	return allResources, nil
+	return result, nil
 }
 
 // ResourceEventMeta represents a lightweight watch event (Pull Model)
@@ -436,12 +379,22 @@ func makeResourceKey(context, namespace, name string) string {
 
 // StartWatch starts watching resources for the given GVK across specified contexts
 // Watch events are emitted via Wails runtime events ("resource:update")
-func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string) error {
+// selectedFields: field paths to extract (e.g., "status.phase", "spec.replicas")
+// Pass selected fields HERE (not via SetSelectedFields) to ensure they're
+// available during initial sync for memory-efficient field extraction.
+//
+// ASYNC BEHAVIOR: This function returns immediately after setting up.
+// Initial sync happens in background goroutines for each context.
+// When sync completes, "sync:complete" event is emitted with total count.
+// Frontend should listen for this event instead of calling GetAllResourceKeys immediately.
+func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string, selectedFields []string) error {
+	log.Printf("[DEBUG] StartWatch: starting for %s/%s/%s with %d contexts, %d selectedFields",
+		gvk.Group, gvk.Version, gvk.Kind, len(contexts), len(selectedFields))
+
 	// Stop any existing watch first
 	a.StopWatch()
 
 	a.watchMu.Lock()
-	defer a.watchMu.Unlock()
 
 	schemaGVK := schema.GroupVersionKind{
 		Group:   gvk.Group,
@@ -454,7 +407,45 @@ func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string) error {
 	a.watchDone = make(chan struct{})
 	a.fieldStore = kube.NewFieldStore()
 
-	var wg sync.WaitGroup
+	// Set selected fields BEFORE initial sync so they're extracted properly.
+	// This is critical for memory optimization - objects are GC'd after extraction.
+	if len(selectedFields) > 0 {
+		a.fieldStore.SetSelectedFields(selectedFields)
+	}
+
+	// Capture fieldStore reference for goroutines
+	fs := a.fieldStore
+	watchDone := a.watchDone
+
+	a.watchMu.Unlock()
+
+	// Start informers in parallel goroutines for faster initial sync
+	var syncWg sync.WaitGroup
+	var eventWg sync.WaitGroup
+	var mu sync.Mutex // protects controllers and stopChs slices
+
+	// Progress tracking for batch events (reduces event flood from 6000+ to ~60)
+	// Use a channel to emit events from a dedicated goroutine (more reliable than emitting from informer callbacks)
+	const progressBatchSize = 100
+	var progressCount atomic.Int64
+	progressCh := make(chan int64, 100) // buffered channel for progress updates
+	progressDone := make(chan struct{})
+
+	// Dedicated goroutine for emitting progress events
+	// This ensures events are emitted from a consistent goroutine context
+	go func() {
+		defer close(progressDone)
+		var lastEmitted int64
+		for count := range progressCh {
+			if count-lastEmitted >= progressBatchSize {
+				lastEmitted = count
+				log.Printf("[DEBUG] Emitting sync:progress with count=%d", count)
+				runtime.EventsEmit(a.ctx, "sync:progress", map[string]any{
+					"count": count,
+				})
+			}
+		}
+	}()
 
 	for _, contextName := range contexts {
 		gvr, err := kube.GetGVRForContext(contextName, schemaGVK)
@@ -463,79 +454,118 @@ func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string) error {
 			continue
 		}
 
-		controller := kube.NewResourceControllerForContext(contextName, gvr)
-		ctx := contextName // capture for closures
+		syncWg.Add(1)
+		go func(ctx string, gvr schema.GroupVersionResource) {
+			defer syncWg.Done()
 
-		// Synchronous callback for initial sync - called in informer's goroutine, no race condition.
-		// This populates FieldStore directly during WaitForCacheSync, before any event can be dropped.
-		onSync := func(eventType kube.EventType, obj *unstructured.Unstructured) {
-			key := makeResourceKey(ctx, obj.GetNamespace(), obj.GetName())
-			if eventType == kube.EventDeleted {
-				a.fieldStore.Delete(key)
-			} else {
-				a.fieldStore.Update(key, obj)
-			}
-			// Note: We don't emit events to frontend during initial sync.
-			// Frontend calls GetAllResourceKeys() after StartWatch returns.
-		}
+			controller := kube.NewResourceControllerForContext(ctx, gvr)
 
-		// Start the informer with KeyOnlyStore for memory efficiency.
-		// The onSync callback processes all initial objects synchronously.
-		// After sync completes, ongoing events are emitted via WatchEvents() channel.
-		stopCh, err := controller.InformWithKeyOnlyStore(onSync)
-		if err != nil {
-			log.Printf("Warning: failed to start watch for %s in context %s: %v", schemaGVK.Kind, contextName, err)
-			continue
-		}
+			// Synchronous callback for initial sync - called in informer's goroutine.
+			// This populates FieldStore AND emits batch progress events for progressive loading.
+			// Instead of 6000+ individual events (overwhelms JS), emit ~60 progress events.
+			onSync := func(eventType kube.EventType, obj *unstructured.Unstructured) {
+				key := makeResourceKey(ctx, obj.GetNamespace(), obj.GetName())
+				if eventType == kube.EventDeleted {
+					fs.Delete(key)
+				} else {
+					fs.Update(key, obj)
+				}
 
-		log.Printf("Initial sync complete for context %s, FieldStore count: %d", ctx, a.fieldStore.Count())
-
-		a.controllers = append(a.controllers, &watchController{
-			contextName: ctx,
-			controller:  controller,
-		})
-		a.stopChs = append(a.stopChs, stopCh)
-
-		// Start goroutine to forward ONGOING events to frontend (after initial sync).
-		// These are real-time updates from watch, not initial list.
-		wg.Add(1)
-		go func(ctxName string, ctrl *kube.ResourceController) {
-			defer wg.Done()
-			for {
+				// Send progress update to dedicated emitter goroutine (non-blocking)
+				newCount := progressCount.Add(1)
 				select {
-				case event := <-ctrl.WatchEvents():
-					if event.Obj == nil {
-						continue // skip invalid events
-					}
-
-					key := makeResourceKey(ctxName, event.Obj.GetNamespace(), event.Obj.GetName())
-
-					if string(event.Type) == "DELETED" {
-						a.fieldStore.Delete(key)
-					} else {
-						a.fieldStore.Update(key, event.Obj)
-					}
-
-					// Emit only lightweight metadata (no full object via eval)
-					runtime.EventsEmit(a.ctx, "resource:update", ResourceEventMeta{
-						Type: string(event.Type),
-						Key:  key,
-					})
-				case <-ctrl.Done():
-					return
+				case progressCh <- newCount:
+				default:
+					// Channel full, skip this update (next one will catch up)
 				}
 			}
-		}(ctx, controller)
+
+			// Start the informer with KeyOnlyStore for memory efficiency.
+			// This BLOCKS until initial sync completes (WaitForCacheSync).
+			stopCh, err := controller.InformWithKeyOnlyStore(onSync)
+			if err != nil {
+				log.Printf("Warning: failed to start watch for %s in context %s: %v", schemaGVK.Kind, ctx, err)
+				return
+			}
+
+			log.Printf("Initial sync complete for context %s, FieldStore count: %d", ctx, fs.Count())
+
+			// Register controller under lock
+			mu.Lock()
+			a.watchMu.Lock()
+			a.controllers = append(a.controllers, &watchController{
+				contextName: ctx,
+				controller:  controller,
+			})
+			a.stopChs = append(a.stopChs, stopCh)
+			a.watchMu.Unlock()
+			mu.Unlock()
+
+			// Start goroutine to forward ONGOING events to frontend (after initial sync).
+			eventWg.Add(1)
+			go func(ctxName string, ctrl *kube.ResourceController) {
+				defer eventWg.Done()
+				for {
+					select {
+					case event := <-ctrl.WatchEvents():
+						if event.Obj == nil {
+							continue
+						}
+
+						key := makeResourceKey(ctxName, event.Obj.GetNamespace(), event.Obj.GetName())
+
+						// Get fieldStore reference under lock to avoid race with StopWatch
+						a.watchMu.RLock()
+						currentFs := a.fieldStore
+						a.watchMu.RUnlock()
+
+						if currentFs == nil {
+							continue
+						}
+
+						if string(event.Type) == "DELETED" {
+							currentFs.Delete(key)
+						} else {
+							currentFs.Update(key, event.Obj)
+						}
+
+						runtime.EventsEmit(a.ctx, "resource:update", ResourceEventMeta{
+							Type: string(event.Type),
+							Key:  key,
+						})
+					case <-ctrl.Done():
+						return
+					}
+				}
+			}(ctx, controller)
+		}(contextName, gvr)
 	}
 
-	// Wait for all event forwarders to finish in background
+	// Background goroutine: wait for all initial syncs, then emit sync:complete
 	go func() {
-		wg.Wait()
-		close(a.watchDone)
+		syncWg.Wait()
+
+		// Close progress channel and wait for emitter to finish
+		close(progressCh)
+		<-progressDone
+
+		count := fs.Count()
+		log.Printf("All initial syncs complete, total FieldStore count: %d", count)
+		logMemoryStats("StartWatch-SyncComplete")
+
+		// Emit sync:complete event so frontend knows data is ready
+		runtime.EventsEmit(a.ctx, "sync:complete", map[string]any{
+			"count": count,
+		})
 	}()
 
-	log.Printf("Started watching %s/%s/%s across %d contexts", gvk.Group, gvk.Version, gvk.Kind, len(a.controllers))
-	logMemoryStats("StartWatch")
+	// Background goroutine: wait for all event forwarders to finish
+	go func() {
+		eventWg.Wait()
+		close(watchDone)
+	}()
+
+	log.Printf("StartWatch returned (sync in progress in background)")
 	return nil
 }
 
@@ -545,8 +575,11 @@ func (a *App) StopWatch() {
 	defer a.watchMu.Unlock()
 
 	if len(a.stopChs) == 0 {
+		log.Printf("[DEBUG] StopWatch: no active watches to stop")
 		return
 	}
+
+	log.Printf("[DEBUG] StopWatch: stopping %d watches", len(a.stopChs))
 
 	// Close all stop channels to stop informers
 	for _, stopCh := range a.stopChs {
@@ -588,21 +621,34 @@ func (a *App) StopWatch() {
 // Called by frontend when user changes column selection.
 // Fields should be dot-notation paths like "status.phase", "spec.replicas".
 func (a *App) SetSelectedFields(fields []string) {
-	if a.fieldStore != nil {
-		a.fieldStore.SetSelectedFields(fields)
+	// Get fieldStore reference under lock to avoid race with StopWatch
+	a.watchMu.RLock()
+	fs := a.fieldStore
+	a.watchMu.RUnlock()
+
+	if fs != nil {
+		fs.SetSelectedFields(fields)
 	}
 }
 
 // GetResourcesByKeys fetches resources from FieldStore by keys (Pull Model)
 // Called by frontend after receiving resource:update events
 func (a *App) GetResourcesByKeys(keys []string) []map[string]any {
+	log.Printf("[DEBUG] GetResourcesByKeys: called with %d keys", len(keys))
+
+	// Get fieldStore reference under lock to avoid race with StopWatch
+	a.watchMu.RLock()
+	fs := a.fieldStore
+	a.watchMu.RUnlock()
+
 	result := make([]map[string]any, 0, len(keys))
-	if a.fieldStore == nil {
+	if fs == nil {
+		log.Printf("[DEBUG] GetResourcesByKeys: fieldStore is nil, returning empty")
 		return result
 	}
 
 	for _, key := range keys {
-		if obj := a.fieldStore.ReconstructObject(key); obj != nil {
+		if obj := fs.ReconstructObject(key); obj != nil {
 			// Extract context from key (format: "context/namespace/name")
 			parts := strings.SplitN(key, "/", 2)
 			if len(parts) > 0 {
@@ -622,10 +668,13 @@ func (a *App) GetAllResourceKeys() []string {
 	defer a.watchMu.RUnlock()
 
 	if a.fieldStore == nil {
+		log.Printf("[DEBUG] GetAllResourceKeys: fieldStore is nil, returning empty")
 		return []string{}
 	}
 
-	return a.fieldStore.List()
+	keys := a.fieldStore.List()
+	log.Printf("[DEBUG] GetAllResourceKeys: returning %d keys", len(keys))
+	return keys
 }
 
 // convertNodeTree converts kube.Node map to frontend TreeNode array

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -365,11 +365,14 @@ func (a *App) GetResources(gvk MultiClusterGVK, contexts []string) ([]map[string
 	return result, nil
 }
 
-// ResourceEventMeta represents a lightweight watch event (Pull Model)
-// Only contains metadata - frontend fetches full object via GetResources()
+// ResourceEventMeta represents a watch event with optional delta data.
+// For ADDED/MODIFIED: includes Fields (reconstructed object) for direct frontend update.
+// For DELETED: Fields is omitted.
+// This eliminates the need for frontend to call GetResourcesByKeys for real-time updates.
 type ResourceEventMeta struct {
-	Type string `json:"type"` // "ADDED", "MODIFIED", "DELETED"
-	Key  string `json:"key"`  // "context/namespace/name" unique identifier
+	Type   string                 `json:"type"`             // "ADDED", "MODIFIED", "DELETED"
+	Key    string                 `json:"key"`              // "context/namespace/name" unique identifier
+	Fields map[string]interface{} `json:"fields,omitempty"` // Reconstructed object (only for ADDED/MODIFIED)
 }
 
 // makeResourceKey creates a unique cache key for a resource
@@ -523,16 +526,37 @@ func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string, selectedFields 
 							continue
 						}
 
-						if string(event.Type) == "DELETED" {
-							currentFs.Delete(key)
-						} else {
-							currentFs.Update(key, event.Obj)
-						}
-
-						runtime.EventsEmit(a.ctx, "resource:update", ResourceEventMeta{
+						eventMeta := ResourceEventMeta{
 							Type: string(event.Type),
 							Key:  key,
-						})
+						}
+
+						if string(event.Type) == "DELETED" {
+							currentFs.Delete(key)
+							// No fields for DELETED events
+						} else {
+							// Update FieldStore first
+							currentFs.Update(key, event.Obj)
+
+							// Include reconstructed object in event (delta update)
+							// This eliminates the need for frontend to call GetResourcesByKeys
+							if cachedFields := currentFs.ReconstructObject(key); cachedFields != nil {
+								// Make a shallow copy since ReconstructObject returns cached object
+								// that should not be modified
+								fields := make(map[string]interface{}, len(cachedFields)+1)
+								for k, v := range cachedFields {
+									fields[k] = v
+								}
+								// Extract context from key (format: "context/namespace/name")
+								parts := strings.SplitN(key, "/", 2)
+								if len(parts) > 0 {
+									fields["_context"] = parts[0]
+								}
+								eventMeta.Fields = fields
+							}
+						}
+
+						runtime.EventsEmit(a.ctx, "resource:update", eventMeta)
 					case <-ctrl.Done():
 						return
 					}

--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -34,11 +34,11 @@ type App struct {
 	favoriteStore *store.Store
 
 	// Watch state
-	watchMu       sync.RWMutex
-	controllers   []*watchController
-	stopChs       []chan struct{}
-	watchDone     chan struct{}
-	resourceCache sync.Map // key: "context/namespace/name" → value: map[string]any
+	watchMu     sync.RWMutex
+	controllers []*watchController
+	stopChs     []chan struct{}
+	watchDone   chan struct{}
+	fieldStore  *kube.FieldStore // key: "context/namespace/name" → value: extracted fields
 }
 
 // watchController wraps a ResourceController with context info
@@ -284,20 +284,21 @@ func (a *App) GetNodeTree(gvk MultiClusterGVK, contexts []string) ([]*TreeNode, 
 		return nil, fmt.Errorf("failed to create field tree: %w", err)
 	}
 
-	// 2. Get resources - prefer active watch store to avoid duplicate List calls
-	objs := a.getWatchedResources()
-	if len(objs) == 0 {
-		// No active watch, fetch directly (with cleanup)
-		objs, err = a.getResourcesWithCleanup(schemaGVK, contexts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get resources: %w", err)
+	// 2. Create node tree - use FieldStore if watches are active (memory-efficient)
+	var nodes map[string]*kube.Node
+	if a.fieldStore.Count() > 0 {
+		// Use FieldStore's structure metadata for tree building
+		nodes = kube.CreateNodeTreeFromStore(fields, a.fieldStore, []string{})
+	} else {
+		// No active watch, fetch resources directly for tree building
+		objs, fetchErr := a.getResourcesWithCleanup(schemaGVK, contexts)
+		if fetchErr != nil {
+			return nil, fmt.Errorf("failed to get resources: %w", fetchErr)
 		}
+		nodes = kube.CreateNodeTree(fields, objs, []string{})
 	}
 
-	// 3. Create node tree
-	nodes := kube.CreateNodeTree(fields, objs, []string{})
-
-	// 4. Convert to frontend format (remove UI state, convert to array)
+	// 3. Convert to frontend format (remove UI state, convert to array)
 	return convertNodeTree(nodes), nil
 }
 
@@ -451,6 +452,7 @@ func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string) error {
 	a.controllers = make([]*watchController, 0, len(contexts))
 	a.stopChs = make([]chan struct{}, 0, len(contexts))
 	a.watchDone = make(chan struct{})
+	a.fieldStore = kube.NewFieldStore()
 
 	var wg sync.WaitGroup
 
@@ -462,21 +464,42 @@ func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string) error {
 		}
 
 		controller := kube.NewResourceControllerForContext(contextName, gvr)
-		stopCh, err := controller.Inform()
+		ctx := contextName // capture for closures
+
+		// Synchronous callback for initial sync - called in informer's goroutine, no race condition.
+		// This populates FieldStore directly during WaitForCacheSync, before any event can be dropped.
+		onSync := func(eventType kube.EventType, obj *unstructured.Unstructured) {
+			key := makeResourceKey(ctx, obj.GetNamespace(), obj.GetName())
+			if eventType == kube.EventDeleted {
+				a.fieldStore.Delete(key)
+			} else {
+				a.fieldStore.Update(key, obj)
+			}
+			// Note: We don't emit events to frontend during initial sync.
+			// Frontend calls GetAllResourceKeys() after StartWatch returns.
+		}
+
+		// Start the informer with KeyOnlyStore for memory efficiency.
+		// The onSync callback processes all initial objects synchronously.
+		// After sync completes, ongoing events are emitted via WatchEvents() channel.
+		stopCh, err := controller.InformWithKeyOnlyStore(onSync)
 		if err != nil {
 			log.Printf("Warning: failed to start watch for %s in context %s: %v", schemaGVK.Kind, contextName, err)
 			continue
 		}
 
+		log.Printf("Initial sync complete for context %s, FieldStore count: %d", ctx, a.fieldStore.Count())
+
 		a.controllers = append(a.controllers, &watchController{
-			contextName: contextName,
+			contextName: ctx,
 			controller:  controller,
 		})
 		a.stopChs = append(a.stopChs, stopCh)
 
-		// Start goroutine to forward events to frontend (Pull Model)
+		// Start goroutine to forward ONGOING events to frontend (after initial sync).
+		// These are real-time updates from watch, not initial list.
 		wg.Add(1)
-		go func(ctx string, ctrl *kube.ResourceController) {
+		go func(ctxName string, ctrl *kube.ResourceController) {
 			defer wg.Done()
 			for {
 				select {
@@ -485,16 +508,12 @@ func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string) error {
 						continue // skip invalid events
 					}
 
-					key := makeResourceKey(ctx, event.Obj.GetNamespace(), event.Obj.GetName())
+					key := makeResourceKey(ctxName, event.Obj.GetNamespace(), event.Obj.GetName())
 
 					if string(event.Type) == "DELETED" {
-						// Remove from cache on delete
-						a.resourceCache.Delete(key)
+						a.fieldStore.Delete(key)
 					} else {
-						// Store in cache for ADDED/MODIFIED
-						obj := event.Obj.Object
-						obj["_context"] = ctx
-						a.resourceCache.Store(key, obj)
+						a.fieldStore.Update(key, event.Obj)
 					}
 
 					// Emit only lightweight metadata (no full object via eval)
@@ -506,7 +525,7 @@ func (a *App) StartWatch(gvk MultiClusterGVK, contexts []string) error {
 					return
 				}
 			}
-		}(contextName, controller)
+		}(ctx, controller)
 	}
 
 	// Wait for all event forwarders to finish in background
@@ -552,11 +571,11 @@ func (a *App) StopWatch() {
 	a.stopChs = nil
 	a.watchDone = nil
 
-	// Clear resource cache
-	a.resourceCache.Range(func(key, value any) bool {
-		a.resourceCache.Delete(key)
-		return true
-	})
+	// Clear field store
+	if a.fieldStore != nil {
+		a.fieldStore.Clear()
+	}
+	a.fieldStore = nil
 
 	log.Printf("Stopped all resource watches")
 	logMemoryStats("StopWatch")
@@ -565,18 +584,48 @@ func (a *App) StopWatch() {
 	kube.ResetEventMetrics()
 }
 
-// GetResourcesByKeys fetches resources from cache by keys (Pull Model)
+// SetSelectedFields updates the fields to extract for table display.
+// Called by frontend when user changes column selection.
+// Fields should be dot-notation paths like "status.phase", "spec.replicas".
+func (a *App) SetSelectedFields(fields []string) {
+	if a.fieldStore != nil {
+		a.fieldStore.SetSelectedFields(fields)
+	}
+}
+
+// GetResourcesByKeys fetches resources from FieldStore by keys (Pull Model)
 // Called by frontend after receiving resource:update events
 func (a *App) GetResourcesByKeys(keys []string) []map[string]any {
 	result := make([]map[string]any, 0, len(keys))
+	if a.fieldStore == nil {
+		return result
+	}
+
 	for _, key := range keys {
-		if obj, ok := a.resourceCache.Load(key); ok {
-			if m, ok := obj.(map[string]any); ok {
-				result = append(result, m)
+		if obj := a.fieldStore.ReconstructObject(key); obj != nil {
+			// Extract context from key (format: "context/namespace/name")
+			parts := strings.SplitN(key, "/", 2)
+			if len(parts) > 0 {
+				obj["_context"] = parts[0]
 			}
+			result = append(result, obj)
 		}
 	}
 	return result
+}
+
+// GetAllResourceKeys returns all resource keys currently in the FieldStore.
+// Called by frontend after StartWatch to get initial batch of keys.
+// This is needed because trySend drops events when buffer is full during initial sync.
+func (a *App) GetAllResourceKeys() []string {
+	a.watchMu.RLock()
+	defer a.watchMu.RUnlock()
+
+	if a.fieldStore == nil {
+		return []string{}
+	}
+
+	return a.fieldStore.List()
 }
 
 // convertNodeTree converts kube.Node map to frontend TreeNode array

--- a/cmd/gui/frontend/CLAUDE.md
+++ b/cmd/gui/frontend/CLAUDE.md
@@ -1,0 +1,97 @@
+# Frontend (React + Wails)
+
+## Stack
+
+- React 18, TypeScript, Vite
+- Tailwind CSS, Radix UI
+- @tanstack/react-table, @tanstack/react-virtual
+
+## Wails IPC
+
+Go 함수 호출:
+```typescript
+window.go.main.App.MethodName()
+```
+
+이벤트 구독:
+```typescript
+import { EventsOn } from '../wailsjs/runtime/runtime';
+EventsOn("event-name", (data) => {
+  // handle event
+});
+```
+
+## Wails Dev Mode
+
+**`wails dev`가 백그라운드에서 실행 중이라고 가정.**
+
+- Go 코드 변경 시 바인딩 자동 재생성
+- Frontend 핫 리로드 자동
+- 명시적 `wails generate module` 불필요
+
+바인딩 위치: `src/wailsjs/` (자동 생성, 수정 금지)
+
+### 바인딩 생성 규칙
+
+```
+wails dev 실행 중?
+├── YES → 바인딩 자동 생성됨, 추가 작업 불필요
+│         (Go 파일 저장 시 수 초 내 반영)
+│
+└── NO  → Fallback: wails generate module 실행
+          bash -c 'cd /path/to/kattle && wails generate module'
+```
+
+**충돌 방지**:
+- `wails dev`가 실행 중일 때 `wails generate module` 실행 금지 (파일 충돌 가능)
+- 바인딩 함수가 이미 존재하면 재생성 불필요 (idempotent)
+- Go 메서드 시그니처 변경 시에만 바인딩 갱신 필요
+
+**확인 방법**:
+```bash
+# wails dev 실행 여부
+pgrep -f "wails dev" && echo "RUNNING" || echo "NOT RUNNING"
+
+# 바인딩 존재 여부 (예: App.ListResources)
+grep -q "ListResources" src/wailsjs/go/main/App.js && echo "EXISTS"
+```
+
+## Key Patterns
+
+- **8000+ 필드 가상화 테이블**: @tanstack/react-virtual 사용
+- **실시간 리소스 업데이트**: `sync:progress` 이벤트 구독
+- **동적 필드 트리 렌더링**: 계층적 JSON 구조 시각화
+
+## Testing
+
+```bash
+npm run test:run    # Vitest + React Testing Library
+npm run test        # Watch mode
+```
+
+## Backend Collaboration
+
+- Go 백엔드 변경 시 Wails 바인딩 재생성 필요 (`wails dev` 실행 중이면 자동)
+- 메모리 최적화는 backend 담당, frontend는 UI 반영만
+- 새 Go 메서드 추가 후: `wails dev` 실행 중이면 자동 반영, 아니면 `wails generate module`
+
+## Directory Structure
+
+```
+src/
+├── components/     # React 컴포넌트
+├── hooks/          # Custom hooks
+├── lib/            # Utilities
+└── wailsjs/        # Generated Wails bindings (DO NOT EDIT)
+```
+
+## Code Quality
+
+See `CODE_QUALITY.md` in this directory for detailed guidelines.
+
+Key rules:
+- No type assertions (`as`)
+- No unused imports
+- Safe array access (check undefined)
+- useCallback for event handlers
+- Complete dependency arrays

--- a/cmd/gui/frontend/CODE_QUALITY.md
+++ b/cmd/gui/frontend/CODE_QUALITY.md
@@ -1,112 +1,52 @@
 # Frontend Code Quality Guidelines
 
-This document defines the code quality standards for the frontend codebase. All code must adhere to these guidelines to ensure TypeScript type safety, React best practices, and code maintainability.
-
 ## Core Principles
 
-- ✅ **No type assertions (`as`)**
-- ✅ **Type safety first**
-- ✅ **No unused imports**
-- ✅ **Explicit type declarations**
-- ✅ **React best practices**
-- ✅ **Focused components** (split when "fat")
+- No type assertions (`as`)
+- No unused imports
+- Safe array access (check undefined)
+- `useCallback` for event handlers
+- Complete dependency arrays
+- Focused components (<300 lines)
 
 ---
 
 ## 1. Type Assertions
 
-### Rule: Never Use Type Assertions
+**Never use type assertions.** They bypass TypeScript's type checking.
 
-Type assertions (`as`) bypass TypeScript's type checking and should be avoided.
-
-**❌ Don't:**
 ```tsx
+// ❌ Don't
 const indices = [] as [number, number][];
 const result = data as MyType;
-```
 
-**✅ Do:**
-```tsx
+// ✅ Do
 const indices: [number, number][] = [];
-const result: MyType = {
-  // Explicit properties
-};
+const result: MyType = { /* explicit properties */ };
 ```
-
-**Rationale:**
-- Type assertions hide type errors
-- They reduce compile-time safety
-- They make refactoring dangerous
 
 ---
 
-## 2. Unused Imports
+## 2. Type Safety
 
-### Rule: Remove All Unused Imports
+### Safe Array Access
 
-Every import must be used in the file.
-
-**❌ Don't:**
 ```tsx
-import { useState, useEffect, useMemo } from "react";
-import { Helper1, Helper2, UnusedHelper } from "./utils";
+// ❌ Don't
+const item = items[index].property;
 
-// UnusedHelper is never used
-```
-
-**✅ Do:**
-```tsx
-import { useState, useEffect } from "react";
-import { Helper1, Helper2 } from "./utils";
-```
-
-**Rationale:**
-- Reduces bundle size
-- Improves code clarity
-- Prevents confusion about dependencies
-
----
-
-## 3. Type Safety
-
-### 3.1 Safe Array Access
-
-Always check for undefined before accessing array elements.
-
-**❌ Don't:**
-```tsx
-const item = items[index].property; // Could throw if undefined
-```
-
-**✅ Do:**
-```tsx
+// ✅ Do
 const item = items[index];
 if (item) {
   const property = item.property;
 }
 ```
 
-### 3.2 Explicit Type Annotations
+### Explicit Type Annotations
 
-Provide explicit types for complex structures.
-
-**❌ Don't:**
 ```tsx
-const results = useMemo(() => {
-  return items.map(item => ({
-    // Inferred type may be too loose
-    id: item.id,
-    name: item.name,
-  }));
-}, [items]);
-```
-
-**✅ Do:**
-```tsx
-interface Result {
-  id: string;
-  name: string;
-}
+// ✅ Do
+interface Result { id: string; name: string; }
 
 const results = useMemo<Result[]>(() => {
   return items.map((item): Result => ({
@@ -116,158 +56,88 @@ const results = useMemo<Result[]>(() => {
 }, [items]);
 ```
 
-### 3.3 React Element Keys
+### React Element Keys
 
-All elements in arrays must have unique, stable keys.
+All list elements must have unique, stable keys.
 
-**❌ Don't:**
 ```tsx
-parts.push(text.substring(0, 5)); // No key
-parts.push(<span>{text}</span>); // No key
-indices.forEach(([start, end], idx) => {
-  parts.push(<mark key={idx}>{text}</mark>); // Index as key
-});
-```
+// ❌ Don't
+parts.push(<mark key={idx}>{text}</mark>); // Index as key
 
-**✅ Do:**
-```tsx
+// ✅ Do
 let keyCounter = 0;
-
-parts.push(
-  <span key={`text-${keyCounter++}`}>
-    {text.substring(0, 5)}
-  </span>
-);
-parts.push(
-  <span key={`text-${keyCounter++}`}>{text}</span>
-);
-indices.forEach(([start, end]) => {
-  parts.push(
-    <mark key={`mark-${keyCounter++}`}>{text}</mark>
-  );
-});
+parts.push(<mark key={`mark-${keyCounter++}`}>{text}</mark>);
 ```
 
 ---
 
-## 4. React Best Practices
+## 3. React Best Practices
 
-### 4.1 Function Memoization
+### useCallback for Handlers
 
-Use `useCallback` for event handlers and functions passed to child components.
-
-**❌ Don't:**
 ```tsx
-const handleClick = (id: string) => {
-  // Function recreated on every render
-  setSelected(id);
-};
-```
+// ❌ Don't
+const handleClick = (id: string) => setSelected(id);
 
-**✅ Do:**
-```tsx
+// ✅ Do
 const handleClick = useCallback((id: string) => {
   setSelected(id);
 }, []);
-
-// Or with dependencies
-const handleClick = useCallback((id: string) => {
-  onSelect(id);
-}, [onSelect]);
 ```
 
-### 4.2 Functional State Updates
+### Functional State Updates
 
-Use functional updates when new state depends on previous state.
+When new state depends on previous state:
 
-**❌ Don't:**
 ```tsx
-const handleToggle = (item: string) => {
-  const newSet = new Set(selectedItems);
-  if (newSet.has(item)) {
-    newSet.delete(item);
-  } else {
-    newSet.add(item);
-  }
-  setSelectedItems(newSet);
-};
-```
-
-**✅ Do:**
-```tsx
+// ✅ Do
 const handleToggle = useCallback((item: string) => {
   setSelectedItems((prev) => {
     const newSet = new Set(prev);
-    if (newSet.has(item)) {
-      newSet.delete(item);
-    } else {
-      newSet.add(item);
-    }
+    newSet.has(item) ? newSet.delete(item) : newSet.add(item);
     return newSet;
   });
 }, []);
 ```
 
-### 4.3 Complete Dependency Arrays
+### Complete Dependency Arrays
 
-Include all dependencies in `useEffect` and `useCallback` dependency arrays.
-
-**❌ Don't:**
 ```tsx
+// ❌ Don't
 useEffect(() => {
-  handleSearch(query); // Missing handleSearch in deps
-}, [query]);
-```
+  handleSearch(query);
+}, [query]); // Missing handleSearch
 
-**✅ Do:**
-```tsx
+// ✅ Do
 useEffect(() => {
   handleSearch(query);
 }, [query, handleSearch]);
 ```
 
-**Note:** This is why handlers should be memoized with `useCallback`.
-
 ---
 
-## 5. Import Organization
+## 4. Imports
 
-### Rule: Import Only What You Need
+### Import Only What You Need
 
-**❌ Don't:**
 ```tsx
+// ❌ Don't
 import * as React from "react";
 import { FC, ReactNode, useState, useEffect, useMemo } from "react";
-```
 
-**✅ Do:**
-```tsx
-import { useState, useEffect, ReactNode } from "react";
+// ✅ Do
+import { useState, useEffect } from "react";
 ```
 
 ### Import Order
 
-1. External dependencies (React, libraries)
-2. Internal dependencies (utils, components)
-3. Type imports (if using `import type`)
-
-```tsx
-// External
-import { useState, useCallback } from "react";
-import fuzzysort from "fuzzysort";
-
-// Internal
-import { Button } from "./ui/button";
-import { useFuzzySearch } from "@/hooks/useFuzzySearch";
-```
+1. External (React, libraries)
+2. Internal (utils, components)
+3. Types (if using `import type`)
 
 ---
 
-## 6. Type Definitions
-
-### 6.1 Interface vs Type
-
-Use `interface` for object shapes, `type` for unions and complex types.
+## 5. Type Definitions
 
 ```tsx
 // Interface for object shapes
@@ -276,16 +146,10 @@ interface User {
   name: string;
 }
 
-// Type for unions and complex types
+// Type for unions
 type Status = "idle" | "loading" | "success" | "error";
-type Result = User | null;
-```
 
-### 6.2 Readonly Types
-
-Use `readonly` for props and data that shouldn't be mutated.
-
-```tsx
+// Readonly for immutable props
 interface Props {
   readonly items: readonly string[];
   readonly onSelect: (id: string) => void;
@@ -294,211 +158,101 @@ interface Props {
 
 ---
 
-## 7. Testing
+## 6. Component Decomposition
 
-### Rule: Write Type-Safe Tests
+### Signs a Component Needs Splitting
 
-Tests should also follow type safety rules.
+- Exceeds ~200-300 lines
+- Handles unrelated UI sections
+- Multiple `useState` for different features
+- Complex state logic
+
+### Extraction Strategies
+
+| Extract to | When |
+|------------|------|
+| **Component** | Visually distinct UI section, reusable |
+| **Custom Hook** | Reusable state logic, complex effects |
+| **Utility Function** | Pure data transformation, no React deps |
 
 ```tsx
-import { describe, it, expect } from 'vitest';
-import { indexesToRanges } from './useFuzzySearch';
+// ❌ Fat component
+function NavigationPanel() {
+  return (
+    <div>
+      <div className="header">
+        {/* 50+ lines */}
+      </div>
+      <div className="context">
+        {/* 50+ lines */}
+      </div>
+    </div>
+  );
+}
 
-describe('indexesToRanges', () => {
-  it('converts continuous indexes to a single range', () => {
-    const input: readonly number[] = [0, 1, 2, 3];
-    const expected: [number, number][] = [[0, 3]];
-    expect(indexesToRanges(input)).toEqual(expected);
-  });
-});
+// ✅ Focused components
+function NavigationPanel() {
+  return (
+    <div>
+      <NavHeader title={title} onCollapse={onCollapse} />
+      <ContextDisplay contexts={contexts} />
+    </div>
+  );
+}
 ```
+
+### When NOT to Split
+
+- Premature abstraction (no clear benefit)
+- Over-fragmentation (single-use 10-line components)
+- Prop drilling (5+ props through layers)
 
 ---
 
-## Enforcement
+## 7. Enforcement
 
 ### Pre-commit Checks
-- Type checking: `tsc --noEmit`
-- Linting: `eslint .`
-- Tests: `npm run test:run`
 
-### Recommended TypeScript Settings
+```bash
+tsc --noEmit          # Type check
+eslint .              # Lint
+npm run test:run      # Tests
+```
+
+### Recommended Config
 
 ```json
+// tsconfig.json
 {
   "compilerOptions": {
     "strict": true,
     "noUncheckedIndexedAccess": true,
-    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true
   }
 }
 ```
 
-### Recommended ESLint Rules
-
 ```json
+// eslint rules
 {
-  "rules": {
-    "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-non-null-assertion": "error",
-    "@typescript-eslint/consistent-type-assertions": ["error", {
-      "assertionStyle": "never"
-    }],
-    "react-hooks/exhaustive-deps": "error",
-    "react/jsx-key": "error"
-  }
+  "@typescript-eslint/consistent-type-assertions": ["error", { "assertionStyle": "never" }],
+  "react-hooks/exhaustive-deps": "error"
 }
 ```
-
----
-
-## 8. Component Decomposition
-
-### Rule: Keep Components Focused and Manageable
-
-When a component becomes too "fat" (doing too much), split it into smaller, focused units.
-
-### 8.1 Signs a Component Needs Splitting
-
-- **Too many lines**: Component exceeds ~200-300 lines
-- **Multiple concerns**: Handles unrelated UI sections or logic
-- **Repeated patterns**: Same structure duplicated within or across files
-- **Complex state**: Multiple `useState` calls managing different features
-- **Mixed data types**: Combines unrelated data types in a single structure via union types
-
-### 8.2 Extraction Strategies
-
-**Extract to Components** when:
-- A UI section is visually distinct (header, sidebar, card, badge)
-- The section has its own props and could be reused
-- It represents a clear "thing" in the UI
-
-```tsx
-// ❌ Don't: Fat component with embedded UI sections
-function NavigationPanel({ ... }) {
-  return (
-    <div>
-      <div className="header">
-        <button onClick={onCollapse}>...</button>
-        <span>{title}</span>
-      </div>
-      <div className="context-display">
-        {/* 50+ lines of context display logic */}
-      </div>
-      {/* ... more sections */}
-    </div>
-  );
-}
-
-// ✅ Do: Extract focused components
-function NavigationPanel({ ... }) {
-  return (
-    <div>
-      <NavHeader title={title} onCollapse={onCollapse} />
-      <ContextDisplay contexts={contexts} />
-      {/* ... */}
-    </div>
-  );
-}
-```
-
-**Extract to Custom Hooks** when:
-- State logic is reusable across components
-- Complex `useEffect` chains or subscriptions
-- Data fetching or transformation logic
-
-```tsx
-// ❌ Don't: Complex inline logic
-function CommandPalette({ items }) {
-  const [query, setQuery] = useState("");
-  const results = useMemo(() => {
-    // 30+ lines of fuzzy search logic
-  }, [items, query]);
-
-  return /* ... */;
-}
-
-// ✅ Do: Extract to custom hook
-function CommandPalette({ items }) {
-  const { query, setQuery, results } = useFuzzySearch(items, getSearchText);
-
-  return /* ... */;
-}
-```
-
-**Extract to Utility Functions** when:
-- Pure data transformation (no React dependencies)
-- Parsing, formatting, or calculation logic
-- Comparison or sorting functions
-
-```tsx
-// ❌ Don't: Inline utility logic
-function CommandPalette() {
-  const parseVersion = (version: string) => {
-    // 20+ lines of version parsing
-  };
-
-  const compareVersions = (a: string, b: string) => {
-    // 20+ lines of comparison logic
-  };
-}
-
-// ✅ Do: Extract to lib/utils
-// lib/version.ts
-export function parseVersion(version: string): VersionInfo { ... }
-export function compareVersions(a: string, b: string): number { ... }
-```
-
-### 8.3 File Organization
-
-When extracting components:
-- Place in the same directory if tightly coupled
-- Create subdirectories for feature groups (e.g., `components/nav/`)
-- Co-locate related hooks in `hooks/`
-- Co-locate utilities in `lib/`
-
-```
-components/
-├── MainView.tsx
-├── NavigationPanel.tsx
-├── NavHeader.tsx          # Extracted from NavigationPanel
-├── ContextDisplay.tsx     # Extracted from NavigationPanel
-├── ResourceDisplay.tsx    # Extracted from NavigationPanel
-└── ui/
-    └── ...
-hooks/
-├── useFuzzySearch.ts      # Extracted search logic
-└── useCellHighlight.ts
-lib/
-├── version.ts             # Version parsing utilities
-└── csv-export.ts
-```
-
-### 8.4 When NOT to Split
-
-- **Premature abstraction**: Don't extract until there's clear benefit
-- **Over-fragmentation**: Avoid single-use 10-line components
-- **Prop drilling**: If extraction requires passing 5+ props through layers
 
 ---
 
 ## Quick Checklist
 
-Before submitting code, verify:
+Before submitting code:
 
 - [ ] No type assertions (`as`)
 - [ ] No unused imports
-- [ ] All array accesses are safe
+- [ ] Safe array access (check undefined)
 - [ ] Event handlers use `useCallback`
-- [ ] State updates are functional when needed
-- [ ] All dependencies are in dependency arrays
-- [ ] All list items have unique keys
-- [ ] Types are explicitly declared for complex structures
-- [ ] Components are focused (<300 lines, single concern)
+- [ ] Functional state updates when needed
+- [ ] Complete dependency arrays
+- [ ] Unique keys for list items
+- [ ] Components <300 lines, single concern
 - [ ] Tests pass: `npm run test:run`
-
----
-
-*These guidelines are mandatory for all frontend code.*

--- a/cmd/gui/frontend/src/components/DIYTable.tsx
+++ b/cmd/gui/frontend/src/components/DIYTable.tsx
@@ -264,11 +264,17 @@ export const DIYTable = forwardRef<DIYTableHandle, DIYTableProps>(({
   onPreviewClear,
   expandButton,
 }, ref) => {
+  // Convert selectedFields from string[][] to string[] (dot notation) for the hook
+  const selectedFieldPaths = useMemo(() => {
+    return selectedFields.map(field => field.join('.'));
+  }, [selectedFields]);
+
   // Use extracted hook for data fetching (watch enabled for real-time updates)
+  // Pass selectedFields so the backend extracts the correct field values
   const { data, loading, getRowId, changedCells } = useResourceData(
     selectedGVK,
     connectedContexts,
-    { watch: true }
+    { watch: true, selectedFields: selectedFieldPaths }
   );
 
   // Track flashing cells for real-time update visualization

--- a/cmd/gui/frontend/src/hooks/useResourceData.ts
+++ b/cmd/gui/frontend/src/hooks/useResourceData.ts
@@ -114,16 +114,14 @@ export function useResourceData(
     const watchGen = ++watchGenRef.current;
     setError(null);
 
-    // Only clear data if GVK or contexts changed, NOT when only selectedFields changes
-    // This preserves existing data during field selection changes
+    // Always show loading when starting a new watch - this is critical for React Strict Mode
+    // where the effect runs twice but only the first run clears data
+    setLoading(true);
+
+    // Only clear data if GVK or contexts changed
     if (shouldClearData) {
       console.log('useResourceData: clearing data (GVK or contexts changed)');
       setData([]);
-      setLoading(true);
-    } else {
-      // When only selectedFields changes, don't show loading since data is already visible
-      // The batch processor will update data incrementally
-      console.log('useResourceData: preserving data (only selectedFields changed)');
     }
 
     setWatchStatus('connecting');
@@ -132,9 +130,6 @@ export function useResourceData(
     // Always reset these flags when starting a new watch - flush will set loading=false after first batch
     hasReceivedFirstBatch.current = false;
     hasReceivedAnyEvent.current = false;
-
-    // Initial sync timeout - if no data arrives within this time, assume sync is complete
-    let initialSyncTimeout: ReturnType<typeof setTimeout> | null = null;
 
     // Chain the start operation to ensure previous stop completes first
     const startOperation = watchOperationRef.current
@@ -149,16 +144,9 @@ export function useResourceData(
         // Initial sync happens in background - wait for sync:complete event.
         console.log(`useResourceData: watch setup complete for ${gvk.kind}, waiting for sync:complete`);
         setWatchStatus('connected');
-
-        // Set a longer timeout for truly empty resources (no sync:complete within 5s)
-        initialSyncTimeout = setTimeout(() => {
-          if (watchGen !== watchGenRef.current) return;
-          if (!hasReceivedFirstBatch.current && !hasReceivedAnyEvent.current) {
-            console.log(`useResourceData: sync timeout for ${gvk.kind}, assuming 0 resources`);
-            setLoading(false);
-            hasReceivedFirstBatch.current = true;
-          }
-        }, 5000);
+        // No timeout - loading state is managed by:
+        // 1. flush() after first batch of data
+        // 2. sync:complete with count=0 for empty resources
       })
       .catch((err) => {
         if (watchGen !== watchGenRef.current) return;
@@ -207,12 +195,6 @@ export function useResourceData(
       console.log(`useResourceData: sync:complete received with ${data.count} items for ${gvk.kind}`);
       hasReceivedAnyEvent.current = true;
 
-      // Clear the timeout since sync completed
-      if (initialSyncTimeout) {
-        clearTimeout(initialSyncTimeout);
-        initialSyncTimeout = null;
-      }
-
       // Fetch final keys after sync complete
       try {
         const allKeys = await GetAllResourceKeys();
@@ -251,12 +233,9 @@ export function useResourceData(
       }
     });
 
-    // Cleanup - only clear timeout and unsubscribe
+    // Cleanup - unsubscribe event listeners
     // StopWatch is called in the chained operation to avoid race conditions
     return () => {
-      if (initialSyncTimeout) {
-        clearTimeout(initialSyncTimeout);
-      }
       unsubscribeSyncProgress();
       unsubscribeSyncComplete();
       unsubscribeResourceUpdate();

--- a/cmd/gui/frontend/src/hooks/useResourceData.ts
+++ b/cmd/gui/frontend/src/hooks/useResourceData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
-import { StartWatch, StopWatch, GetResourcesByKeys, GetAllResourceKeys } from '../../wailsjs/go/main/App';
+import { StartWatch, StopWatch, GetResourcesByKeys, GetAllResourceKeys, SetSelectedFields } from '../../wailsjs/go/main/App';
 import type { main } from '../../wailsjs/go/models';
 import { getResourceKey, type ResourceEventMeta, type CellChange, diffFields } from '../lib/resource-utils';
 
@@ -12,6 +12,10 @@ export interface UseResourceDataOptions {
   watch?: boolean;
   /** Batch interval in ms for fetching resources (default: 100) */
   batchInterval?: number;
+  /** Selected field paths to extract (e.g., "status.phase", "spec.replicas").
+   * Pass this to enable memory-efficient selective field extraction.
+   * Without this, only essential metadata fields are returned. */
+  selectedFields?: string[];
 }
 
 export interface UseResourceDataResult {
@@ -48,7 +52,10 @@ export function useResourceData(
   contexts: string[],
   options: UseResourceDataOptions = {}
 ): UseResourceDataResult {
-  const { watch = true, batchInterval = 100 } = options;
+  const { watch = true, batchInterval = 100, selectedFields = [] } = options;
+
+  // Serialize selectedFields for stable dependency comparison (avoid restart on same content, different reference)
+  const selectedFieldsKey = JSON.stringify(selectedFields);
 
   const [data, setData] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
@@ -58,6 +65,11 @@ export function useResourceData(
 
   // Track watch generation to avoid stale operations
   const watchGenRef = useRef(0);
+
+  // Track previous GVK and contexts to detect what changed
+  // This allows preserving data when only selectedFields changes
+  const prevGvkRef = useRef<main.MultiClusterGVK | null>(null);
+  const prevContextsKeyRef = useRef<string>('');
 
   // Pending keys for ADDED/MODIFIED events (Pull Model)
   const pendingKeys = useRef<Set<string>>(new Set());
@@ -81,16 +93,43 @@ export function useResourceData(
       setLoading(false);
       setError(null);
       setWatchStatus('disconnected');
+      prevGvkRef.current = null;
+      prevContextsKeyRef.current = '';
       return;
     }
 
+    // Determine what changed to decide whether to clear data
+    const currentContextsKey = JSON.stringify(contexts);
+    const isGvkChanged = !prevGvkRef.current ||
+      gvk.group !== prevGvkRef.current.group ||
+      gvk.version !== prevGvkRef.current.version ||
+      gvk.kind !== prevGvkRef.current.kind;
+    const isContextsChanged = currentContextsKey !== prevContextsKeyRef.current;
+    const shouldClearData = isGvkChanged || isContextsChanged;
+
+    // Update refs for next comparison
+    prevGvkRef.current = gvk;
+    prevContextsKeyRef.current = currentContextsKey;
+
     const watchGen = ++watchGenRef.current;
-    setLoading(true);
     setError(null);
-    setData([]);
+
+    // Only clear data if GVK or contexts changed, NOT when only selectedFields changes
+    // This preserves existing data during field selection changes
+    if (shouldClearData) {
+      console.log('useResourceData: clearing data (GVK or contexts changed)');
+      setData([]);
+      setLoading(true);
+    } else {
+      // When only selectedFields changes, don't show loading since data is already visible
+      // The batch processor will update data incrementally
+      console.log('useResourceData: preserving data (only selectedFields changed)');
+    }
+
     setWatchStatus('connecting');
     pendingKeys.current.clear();
     pendingDeletes.current.clear();
+    // Always reset these flags when starting a new watch - flush will set loading=false after first batch
     hasReceivedFirstBatch.current = false;
     hasReceivedAnyEvent.current = false;
 
@@ -102,41 +141,24 @@ export function useResourceData(
       .then(() => StopWatch().catch(() => {})) // Stop any existing watch first, ignore errors
       .then(() => {
         if (watchGen !== watchGenRef.current) return;
-        return StartWatch(gvk, contexts);
+        return StartWatch(gvk, contexts, selectedFields);
       })
-      .then(async () => {
+      .then(() => {
         if (watchGen !== watchGenRef.current) return;
-        console.log(`useResourceData: watch connected for ${gvk.kind}`);
+        // StartWatch now returns immediately (async behavior).
+        // Initial sync happens in background - wait for sync:complete event.
+        console.log(`useResourceData: watch setup complete for ${gvk.kind}, waiting for sync:complete`);
         setWatchStatus('connected');
 
-        // Fetch all keys from FieldStore after initial sync completes.
-        // This is critical because trySend drops events when buffer is full during initial sync.
-        // Without this, only a fraction of resources would be displayed.
-        try {
-          const allKeys = await GetAllResourceKeys();
-          if (watchGen !== watchGenRef.current) return;
-          if (allKeys && allKeys.length > 0) {
-            console.log(`useResourceData: fetched ${allKeys.length} initial keys for ${gvk.kind}`);
-            hasReceivedAnyEvent.current = true;
-            for (const key of allKeys) {
-              pendingKeys.current.add(key);
-            }
-          }
-        } catch (err) {
-          console.error('useResourceData: failed to get initial keys:', err);
-        }
-
-        // Set timeout to complete loading only if no events have been received
-        // This handles GVKs with 0 resources
+        // Set a longer timeout for truly empty resources (no sync:complete within 5s)
         initialSyncTimeout = setTimeout(() => {
           if (watchGen !== watchGenRef.current) return;
-          // Only trigger timeout if no events at all (truly 0 resources)
           if (!hasReceivedFirstBatch.current && !hasReceivedAnyEvent.current) {
-            console.log(`useResourceData: initial sync timeout for ${gvk.kind}, no events received, completing loading`);
+            console.log(`useResourceData: sync timeout for ${gvk.kind}, assuming 0 resources`);
             setLoading(false);
             hasReceivedFirstBatch.current = true;
           }
-        }, 500);
+        }, 5000);
       })
       .catch((err) => {
         if (watchGen !== watchGenRef.current) return;
@@ -148,8 +170,72 @@ export function useResourceData(
 
     watchOperationRef.current = startOperation;
 
-    // Subscribe to lightweight events (Pull Model)
-    const unsubscribe = EventsOn('resource:update', (event: ResourceEventMeta) => {
+    // Subscribe to sync:progress event (emitted every 100 items during sync)
+    // This allows progressive loading without overwhelming JS with 6000+ individual events
+    const unsubscribeSyncProgress = EventsOn('sync:progress', async (data: { count: number }) => {
+      if (watchGen !== watchGenRef.current) {
+        console.log(`useResourceData: sync:progress SKIPPED (watchGen mismatch: ${watchGen} vs ${watchGenRef.current})`);
+        return;
+      }
+
+      console.log(`useResourceData: sync:progress received with ${data.count} items for ${gvk.kind}, watchGen=${watchGen}`);
+      hasReceivedAnyEvent.current = true;
+
+      // Fetch all available keys from FieldStore for progressive loading
+      try {
+        const allKeys = await GetAllResourceKeys();
+        if (watchGen !== watchGenRef.current) {
+          console.log(`useResourceData: sync:progress - SKIPPED after fetch (watchGen changed)`);
+          return;
+        }
+        if (allKeys && allKeys.length > 0) {
+          console.log(`useResourceData: sync:progress - fetched ${allKeys.length} keys, adding to pendingKeys (current size: ${pendingKeys.current.size})`);
+          for (const key of allKeys) {
+            pendingKeys.current.add(key);
+          }
+          console.log(`useResourceData: sync:progress - pendingKeys size after add: ${pendingKeys.current.size}`);
+        }
+      } catch (err) {
+        console.error('useResourceData: failed to get keys during sync:progress:', err);
+      }
+    });
+
+    // Subscribe to sync:complete event (emitted when initial sync finishes)
+    const unsubscribeSyncComplete = EventsOn('sync:complete', async (data: { count: number }) => {
+      if (watchGen !== watchGenRef.current) return;
+
+      console.log(`useResourceData: sync:complete received with ${data.count} items for ${gvk.kind}`);
+      hasReceivedAnyEvent.current = true;
+
+      // Clear the timeout since sync completed
+      if (initialSyncTimeout) {
+        clearTimeout(initialSyncTimeout);
+        initialSyncTimeout = null;
+      }
+
+      // Fetch final keys after sync complete
+      try {
+        const allKeys = await GetAllResourceKeys();
+        if (watchGen !== watchGenRef.current) return;
+        if (allKeys && allKeys.length > 0) {
+          console.log(`useResourceData: sync:complete - fetched ${allKeys.length} final keys`);
+          for (const key of allKeys) {
+            pendingKeys.current.add(key);
+          }
+        } else if (data.count === 0) {
+          // No resources - complete loading immediately
+          console.log(`useResourceData: sync:complete with 0 items, marking loading complete`);
+          setLoading(false);
+          hasReceivedFirstBatch.current = true;
+        }
+      } catch (err) {
+        console.error('useResourceData: failed to get keys on sync:complete:', err);
+        setLoading(false);
+      }
+    });
+
+    // Subscribe to lightweight events (Pull Model) for real-time updates
+    const unsubscribeResourceUpdate = EventsOn('resource:update', (event: ResourceEventMeta) => {
       if (watchGen !== watchGenRef.current) return;
 
       // Mark that we've received at least one event (for timeout decision)
@@ -171,9 +257,14 @@ export function useResourceData(
       if (initialSyncTimeout) {
         clearTimeout(initialSyncTimeout);
       }
-      unsubscribe();
+      unsubscribeSyncProgress();
+      unsubscribeSyncComplete();
+      unsubscribeResourceUpdate();
       setWatchStatus('disconnected');
     };
+    // NOTE: selectedFieldsKey is intentionally NOT a dependency here.
+    // Changing selectedFields should NOT restart the watch (which clears FieldStore).
+    // Instead, a separate effect handles selectedFields updates via SetSelectedFields API.
   }, [watch, gvk, contexts]);
 
   // Cleanup on unmount - ensure watch is stopped
@@ -185,7 +276,59 @@ export function useResourceData(
     };
   }, []);
 
+  // Track initial selectedFields to skip the first run (initial selectedFields passed to StartWatch)
+  const initialSelectedFieldsKeyRef = useRef<string | null>(null);
+
+  // Handle selectedFields changes WITHOUT restarting watch
+  // This effect updates the backend field list and queues a re-fetch of all existing data
+  useEffect(() => {
+    // Skip if watch is not active
+    if (!watch || !gvk || watchStatus !== 'connected') {
+      return;
+    }
+
+    // Skip the first run - initial selectedFields are already passed to StartWatch
+    if (initialSelectedFieldsKeyRef.current === null) {
+      initialSelectedFieldsKeyRef.current = selectedFieldsKey;
+      return;
+    }
+
+    // Skip if selectedFields haven't actually changed
+    if (initialSelectedFieldsKeyRef.current === selectedFieldsKey) {
+      return;
+    }
+
+    // Update ref for next comparison
+    initialSelectedFieldsKeyRef.current = selectedFieldsKey;
+
+    console.log('useResourceData: selectedFields changed, updating backend without watch restart');
+
+    // Update backend selectedFields (new/modified resources will use new fields)
+    SetSelectedFields(selectedFields)
+      .then(async () => {
+        // Queue all existing keys for re-fetch to get data with new field extraction
+        // Note: Backend re-extracts data from FieldStore when fields change
+        try {
+          const allKeys = await GetAllResourceKeys();
+          if (allKeys && allKeys.length > 0) {
+            console.log(`useResourceData: queuing ${allKeys.length} keys for re-fetch with new fields`);
+            for (const key of allKeys) {
+              pendingKeys.current.add(key);
+            }
+          }
+        } catch (err) {
+          console.error('useResourceData: failed to get keys for re-fetch:', err);
+        }
+      })
+      .catch((err) => {
+        console.error('useResourceData: failed to update selectedFields:', err);
+      });
+  }, [watch, gvk, watchStatus, selectedFieldsKey, selectedFields]);
+
   // Batch processor: fetch resources and apply updates (Pull Model)
+  // Chunk size for fetching resources - prevents overwhelming the system with large batches
+  const FETCH_CHUNK_SIZE = 500;
+
   useEffect(() => {
     if (!watch || !gvk) return;
 
@@ -194,18 +337,35 @@ export function useResourceData(
 
     const flush = async () => {
       // Check if GVK has changed since this effect started
-      if (currentWatchGen !== watchGenRef.current) return;
+      if (currentWatchGen !== watchGenRef.current) {
+        console.log(`useResourceData flush: skipping (watchGen mismatch: ${currentWatchGen} vs ${watchGenRef.current})`);
+        return;
+      }
 
-      const keysToFetch = Array.from(pendingKeys.current);
+      // Take only a chunk of pending keys to avoid overwhelming the system
+      const allPendingKeys = Array.from(pendingKeys.current);
+      const keysToFetch = allPendingKeys.slice(0, FETCH_CHUNK_SIZE);
       const keysToDelete = Array.from(pendingDeletes.current);
 
-      // Clear pending sets
-      pendingKeys.current.clear();
+      // Debug log to see if flush is being called with keys
+      if (allPendingKeys.length > 0 || keysToDelete.length > 0) {
+        console.log(`useResourceData flush: pending=${allPendingKeys.length}, toFetch=${keysToFetch.length}, toDelete=${keysToDelete.length}`);
+      }
+
+      // Remove fetched keys from pending (keep remaining for next batch)
+      for (const key of keysToFetch) {
+        pendingKeys.current.delete(key);
+      }
       pendingDeletes.current.clear();
 
       // Nothing to do
       if (keysToFetch.length === 0 && keysToDelete.length === 0) {
         return;
+      }
+
+      // Log progress for large batches
+      if (allPendingKeys.length > FETCH_CHUNK_SIZE) {
+        console.log(`useResourceData: fetching chunk ${keysToFetch.length}/${allPendingKeys.length} keys`);
       }
 
       // Fetch resources for ADDED/MODIFIED keys
@@ -288,34 +448,59 @@ export function useResourceData(
       .then(() => StopWatch().catch(() => {}))
       .then(() => {
         if (watchGen !== watchGenRef.current) return;
-        return StartWatch(gvk, contexts);
+        return StartWatch(gvk, contexts, selectedFields);
       })
-      .then(async () => {
+      .then(() => {
         if (watchGen !== watchGenRef.current) return;
         setWatchStatus('connected');
+        console.log(`useResourceData: refresh - watch setup complete, waiting for sync:complete`);
 
-        // Fetch all keys from FieldStore after initial sync completes
-        try {
-          const allKeys = await GetAllResourceKeys();
-          if (watchGen !== watchGenRef.current) return;
-          if (allKeys && allKeys.length > 0) {
-            hasReceivedAnyEvent.current = true;
-            for (const key of allKeys) {
-              pendingKeys.current.add(key);
+        // Wait for sync:complete event with one-time listener
+        // NOTE: Events are now emitted DURING sync, so data is shown progressively.
+        // sync:complete just signals initial list is complete.
+        return new Promise<void>((resolve) => {
+          let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+          const unsubscribe = EventsOn('sync:complete', (data: { count: number }) => {
+            if (watchGen !== watchGenRef.current) {
+              unsubscribe();
+              if (timeoutId) clearTimeout(timeoutId);
+              resolve();
+              return;
             }
-          }
-        } catch (err) {
-          console.error('useResourceData: failed to get initial keys on refresh:', err);
-        }
 
-        // Set timeout to complete loading only if no events received
-        setTimeout(() => {
-          if (watchGen !== watchGenRef.current) return;
-          if (!hasReceivedFirstBatch.current && !hasReceivedAnyEvent.current) {
-            setLoading(false);
-            hasReceivedFirstBatch.current = true;
-          }
-        }, 500);
+            unsubscribe(); // One-time listener
+            if (timeoutId) clearTimeout(timeoutId);
+
+            console.log(`useResourceData: refresh - sync:complete with ${data.count} items`);
+            hasReceivedAnyEvent.current = true;
+
+            // If no data, mark loading complete immediately
+            if (data.count === 0) {
+              setLoading(false);
+              hasReceivedFirstBatch.current = true;
+            }
+            // Otherwise, batch processor will set loading=false after first batch
+
+            resolve();
+          });
+
+          // Timeout fallback for truly empty resources
+          timeoutId = setTimeout(() => {
+            if (watchGen !== watchGenRef.current) {
+              unsubscribe();
+              resolve();
+              return;
+            }
+            console.log(`useResourceData: refresh - sync timeout, assuming 0 resources`);
+            unsubscribe();
+            if (!hasReceivedFirstBatch.current && !hasReceivedAnyEvent.current) {
+              setLoading(false);
+              hasReceivedFirstBatch.current = true;
+            }
+            resolve();
+          }, 5000);
+        });
       })
       .catch((err) => {
         if (watchGen !== watchGenRef.current) return;
@@ -324,7 +509,7 @@ export function useResourceData(
       });
 
     watchOperationRef.current = refreshOperation;
-  }, [gvk, contexts]);
+  }, [gvk, contexts, selectedFields]);
 
   // Stable row ID function for TanStack Table
   const getRowId = useCallback((row: any) => {

--- a/cmd/gui/frontend/src/hooks/useResourceData.ts
+++ b/cmd/gui/frontend/src/hooks/useResourceData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
-import { StartWatch, StopWatch, GetResourcesByKeys } from '../../wailsjs/go/main/App';
+import { StartWatch, StopWatch, GetResourcesByKeys, GetAllResourceKeys } from '../../wailsjs/go/main/App';
 import type { main } from '../../wailsjs/go/models';
 import { getResourceKey, type ResourceEventMeta, type CellChange, diffFields } from '../lib/resource-utils';
 
@@ -104,10 +104,27 @@ export function useResourceData(
         if (watchGen !== watchGenRef.current) return;
         return StartWatch(gvk, contexts);
       })
-      .then(() => {
+      .then(async () => {
         if (watchGen !== watchGenRef.current) return;
         console.log(`useResourceData: watch connected for ${gvk.kind}`);
         setWatchStatus('connected');
+
+        // Fetch all keys from FieldStore after initial sync completes.
+        // This is critical because trySend drops events when buffer is full during initial sync.
+        // Without this, only a fraction of resources would be displayed.
+        try {
+          const allKeys = await GetAllResourceKeys();
+          if (watchGen !== watchGenRef.current) return;
+          if (allKeys && allKeys.length > 0) {
+            console.log(`useResourceData: fetched ${allKeys.length} initial keys for ${gvk.kind}`);
+            hasReceivedAnyEvent.current = true;
+            for (const key of allKeys) {
+              pendingKeys.current.add(key);
+            }
+          }
+        } catch (err) {
+          console.error('useResourceData: failed to get initial keys:', err);
+        }
 
         // Set timeout to complete loading only if no events have been received
         // This handles GVKs with 0 resources
@@ -273,9 +290,23 @@ export function useResourceData(
         if (watchGen !== watchGenRef.current) return;
         return StartWatch(gvk, contexts);
       })
-      .then(() => {
+      .then(async () => {
         if (watchGen !== watchGenRef.current) return;
         setWatchStatus('connected');
+
+        // Fetch all keys from FieldStore after initial sync completes
+        try {
+          const allKeys = await GetAllResourceKeys();
+          if (watchGen !== watchGenRef.current) return;
+          if (allKeys && allKeys.length > 0) {
+            hasReceivedAnyEvent.current = true;
+            for (const key of allKeys) {
+              pendingKeys.current.add(key);
+            }
+          }
+        } catch (err) {
+          console.error('useResourceData: failed to get initial keys on refresh:', err);
+        }
 
         // Set timeout to complete loading only if no events received
         setTimeout(() => {

--- a/cmd/gui/frontend/src/hooks/useResourceData.ts
+++ b/cmd/gui/frontend/src/hooks/useResourceData.ts
@@ -71,8 +71,11 @@ export function useResourceData(
   const prevGvkRef = useRef<main.MultiClusterGVK | null>(null);
   const prevContextsKeyRef = useRef<string>('');
 
-  // Pending keys for ADDED/MODIFIED events (Pull Model)
+  // Pending keys for ADDED/MODIFIED events (Pull Model - fallback when no fields in event)
   const pendingKeys = useRef<Set<string>>(new Set());
+
+  // Pending delta updates - resources with fields included in event (no GetResourcesByKeys needed)
+  const pendingDeltaUpdates = useRef<Map<string, Record<string, unknown>>>(new Map());
 
   // Pending deletes - keys to remove
   const pendingDeletes = useRef<Set<string>>(new Set());
@@ -126,6 +129,7 @@ export function useResourceData(
 
     setWatchStatus('connecting');
     pendingKeys.current.clear();
+    pendingDeltaUpdates.current.clear();
     pendingDeletes.current.clear();
     // Always reset these flags when starting a new watch - flush will set loading=false after first batch
     hasReceivedFirstBatch.current = false;
@@ -216,7 +220,8 @@ export function useResourceData(
       }
     });
 
-    // Subscribe to lightweight events (Pull Model) for real-time updates
+    // Subscribe to events for real-time updates (Delta Update Model)
+    // If event includes fields, apply directly without GetResourcesByKeys call
     const unsubscribeResourceUpdate = EventsOn('resource:update', (event: ResourceEventMeta) => {
       if (watchGen !== watchGenRef.current) return;
 
@@ -226,9 +231,14 @@ export function useResourceData(
       if (event.type === 'DELETED') {
         // Collect deletes separately
         pendingDeletes.current.add(event.key);
-        pendingKeys.current.delete(event.key); // No need to fetch deleted resources
+        pendingKeys.current.delete(event.key);
+        pendingDeltaUpdates.current.delete(event.key);
+      } else if (event.fields) {
+        // Delta update: fields included in event, no GetResourcesByKeys needed
+        pendingDeltaUpdates.current.set(event.key, event.fields);
+        pendingKeys.current.delete(event.key); // Remove from fallback queue
       } else {
-        // ADDED or MODIFIED - collect key for batch fetch
+        // Fallback: no fields, need to fetch via GetResourcesByKeys
         pendingKeys.current.add(event.key);
       }
     });
@@ -304,8 +314,9 @@ export function useResourceData(
       });
   }, [watch, gvk, watchStatus, selectedFieldsKey, selectedFields]);
 
-  // Batch processor: fetch resources and apply updates (Pull Model)
-  // Chunk size for fetching resources - prevents overwhelming the system with large batches
+  // Batch processor: apply delta updates and fetch remaining resources
+  // Delta updates (with fields in event) are applied directly without GetResourcesByKeys
+  // Fallback keys (no fields) are fetched via GetResourcesByKeys
   const FETCH_CHUNK_SIZE = 500;
 
   useEffect(() => {
@@ -321,14 +332,18 @@ export function useResourceData(
         return;
       }
 
-      // Take only a chunk of pending keys to avoid overwhelming the system
+      // Collect delta updates (resources with fields from events - no fetch needed)
+      const deltaUpdates = new Map(pendingDeltaUpdates.current);
+      pendingDeltaUpdates.current.clear();
+
+      // Take only a chunk of fallback keys to avoid overwhelming the system
       const allPendingKeys = Array.from(pendingKeys.current);
       const keysToFetch = allPendingKeys.slice(0, FETCH_CHUNK_SIZE);
       const keysToDelete = Array.from(pendingDeletes.current);
 
-      // Debug log to see if flush is being called with keys
-      if (allPendingKeys.length > 0 || keysToDelete.length > 0) {
-        console.log(`useResourceData flush: pending=${allPendingKeys.length}, toFetch=${keysToFetch.length}, toDelete=${keysToDelete.length}`);
+      // Debug log to see if flush is being called with data
+      if (deltaUpdates.size > 0 || allPendingKeys.length > 0 || keysToDelete.length > 0) {
+        console.log(`useResourceData flush: delta=${deltaUpdates.size}, fallback=${allPendingKeys.length}, toFetch=${keysToFetch.length}, toDelete=${keysToDelete.length}`);
       }
 
       // Remove fetched keys from pending (keep remaining for next batch)
@@ -338,17 +353,17 @@ export function useResourceData(
       pendingDeletes.current.clear();
 
       // Nothing to do
-      if (keysToFetch.length === 0 && keysToDelete.length === 0) {
+      if (deltaUpdates.size === 0 && keysToFetch.length === 0 && keysToDelete.length === 0) {
         return;
       }
 
       // Log progress for large batches
       if (allPendingKeys.length > FETCH_CHUNK_SIZE) {
-        console.log(`useResourceData: fetching chunk ${keysToFetch.length}/${allPendingKeys.length} keys`);
+        console.log(`useResourceData: fetching chunk ${keysToFetch.length}/${allPendingKeys.length} fallback keys`);
       }
 
-      // Fetch resources for ADDED/MODIFIED keys
-      let fetchedResources: any[] = [];
+      // Fetch resources for fallback keys (no fields in event)
+      let fetchedResources: Record<string, unknown>[] = [];
       if (keysToFetch.length > 0) {
         try {
           fetchedResources = await GetResourcesByKeys(keysToFetch);
@@ -374,7 +389,22 @@ export function useResourceData(
           dataMap.delete(key);
         }
 
-        // Apply fetched resources (ADDED/MODIFIED)
+        // Apply delta updates (ADDED/MODIFIED with fields from events - no fetch needed)
+        for (const [key, resource] of deltaUpdates) {
+          const prevResource = dataMap.get(key);
+
+          // Track changes for MODIFIED
+          if (prevResource) {
+            const changedPaths = diffFields(prevResource, resource);
+            for (const columnId of changedPaths) {
+              changes.push({ rowId: key, columnId, timestamp: now });
+            }
+          }
+
+          dataMap.set(key, resource);
+        }
+
+        // Apply fetched resources (fallback ADDED/MODIFIED)
         for (const resource of fetchedResources) {
           const rowId = getResourceKey(resource);
           const prevResource = dataMap.get(rowId);
@@ -418,6 +448,7 @@ export function useResourceData(
     setError(null);
     setData([]);
     pendingKeys.current.clear();
+    pendingDeltaUpdates.current.clear();
     pendingDeletes.current.clear();
     hasReceivedFirstBatch.current = false;
     hasReceivedAnyEvent.current = false;

--- a/cmd/gui/frontend/src/hooks/useTree.ts
+++ b/cmd/gui/frontend/src/hooks/useTree.ts
@@ -886,6 +886,7 @@ export function useTree({
     if (prevFlatNodesMapRef.current === flatNodesMap) {
       return;
     }
+    const prevSize = prevFlatNodesMapRef.current?.size ?? 0;
     prevFlatNodesMapRef.current = flatNodesMap;
 
     // Use refs to get current values without triggering on their changes
@@ -894,6 +895,13 @@ export function useTree({
 
     if (flatNodesMap.size === 0) return;
     if (currentSelectedPaths.size === 0 && currentExpandedPaths.size === 0) return;
+
+    // Skip cleanup if tree appears to be rebuilding (significantly smaller than before)
+    // This prevents losing selections during watch restart when tree is temporarily incomplete
+    if (prevSize > 0 && flatNodesMap.size < prevSize * 0.5) {
+      console.log(`useTree: skipping stale path cleanup (tree rebuilding: ${flatNodesMap.size} < ${prevSize})`);
+      return;
+    }
 
     const stalePaths: string[] = [];
 

--- a/cmd/gui/frontend/src/lib/resource-utils.ts
+++ b/cmd/gui/frontend/src/lib/resource-utils.ts
@@ -9,11 +9,15 @@
 // Types for resource events
 export type ResourceEventType = 'ADDED' | 'MODIFIED' | 'DELETED';
 
-// Pull Model: lightweight event with only type and key (no full object)
+// Delta update model: event includes optional fields for direct application.
+// For ADDED/MODIFIED: fields contains the reconstructed object.
+// For DELETED: fields is undefined.
 export interface ResourceEventMeta {
   type: ResourceEventType;
   /** Unique key: "context/namespace/name" */
   key: string;
+  /** Reconstructed object for ADDED/MODIFIED events (delta update) */
+  fields?: Record<string, unknown>;
 }
 
 /**

--- a/cmd/gui/frontend/wailsjs/go/main/App.d.ts
+++ b/cmd/gui/frontend/wailsjs/go/main/App.d.ts
@@ -6,6 +6,8 @@ export function ConnectToContexts(arg1:Array<string>):Promise<Array<main.Context
 
 export function DeleteFavoriteView(arg1:string):Promise<void>;
 
+export function GetAllResourceKeys():Promise<Array<string>>;
+
 export function GetCurrentContext():Promise<string>;
 
 export function GetDefaultSelectedPaths(arg1:main.MultiClusterGVK,arg2:Array<string>):Promise<Array<any>>;
@@ -33,6 +35,8 @@ export function RenameFavoriteView(arg1:string,arg2:string):Promise<main.Favorit
 export function SaveFavoriteView(arg1:string,arg2:string,arg3:string,arg4:string,arg5:Array<any>):Promise<main.FavoriteViewResponse>;
 
 export function SaveFile(arg1:string,arg2:string):Promise<string>;
+
+export function SetSelectedFields(arg1:Array<string>):Promise<void>;
 
 export function StartWatch(arg1:main.MultiClusterGVK,arg2:Array<string>):Promise<void>;
 

--- a/cmd/gui/frontend/wailsjs/go/main/App.d.ts
+++ b/cmd/gui/frontend/wailsjs/go/main/App.d.ts
@@ -38,6 +38,6 @@ export function SaveFile(arg1:string,arg2:string):Promise<string>;
 
 export function SetSelectedFields(arg1:Array<string>):Promise<void>;
 
-export function StartWatch(arg1:main.MultiClusterGVK,arg2:Array<string>):Promise<void>;
+export function StartWatch(arg1:main.MultiClusterGVK,arg2:Array<string>,arg3:Array<string>):Promise<void>;
 
 export function StopWatch():Promise<void>;

--- a/cmd/gui/frontend/wailsjs/go/main/App.js
+++ b/cmd/gui/frontend/wailsjs/go/main/App.js
@@ -74,8 +74,8 @@ export function SetSelectedFields(arg1) {
   return window['go']['main']['App']['SetSelectedFields'](arg1);
 }
 
-export function StartWatch(arg1, arg2) {
-  return window['go']['main']['App']['StartWatch'](arg1, arg2);
+export function StartWatch(arg1, arg2, arg3) {
+  return window['go']['main']['App']['StartWatch'](arg1, arg2, arg3);
 }
 
 export function StopWatch() {

--- a/cmd/gui/frontend/wailsjs/go/main/App.js
+++ b/cmd/gui/frontend/wailsjs/go/main/App.js
@@ -10,6 +10,10 @@ export function DeleteFavoriteView(arg1) {
   return window['go']['main']['App']['DeleteFavoriteView'](arg1);
 }
 
+export function GetAllResourceKeys() {
+  return window['go']['main']['App']['GetAllResourceKeys']();
+}
+
 export function GetCurrentContext() {
   return window['go']['main']['App']['GetCurrentContext']();
 }
@@ -64,6 +68,10 @@ export function SaveFavoriteView(arg1, arg2, arg3, arg4, arg5) {
 
 export function SaveFile(arg1, arg2) {
   return window['go']['main']['App']['SaveFile'](arg1, arg2);
+}
+
+export function SetSelectedFields(arg1) {
+  return window['go']['main']['App']['SetSelectedFields'](arg1);
 }
 
 export function StartWatch(arg1, arg2) {

--- a/cmd/gui/main.go
+++ b/cmd/gui/main.go
@@ -45,7 +45,7 @@ func DumpMemory(label string) string {
 
 	dumpSeq++
 	timestamp := time.Now().Format("20060102-150405")
-	filename := filepath.Join(dumpDir, fmt.Sprintf("heap_%s_%s_%03d.pb.gz", label, timestamp, dumpSeq))
+	filename := filepath.Join(dumpDir, fmt.Sprintf("heap_%s_%03d_%s.pb.gz", timestamp, dumpSeq, label))
 
 	f, err := os.Create(filename)
 	if err != nil {

--- a/internal/kube/fieldstore.go
+++ b/internal/kube/fieldstore.go
@@ -29,6 +29,12 @@ type FieldStore struct {
 	// stringPool interns frequently repeated string values to reduce memory.
 	// e.g., status.phase = "Running" is stored once, referenced by all pods.
 	stringPool sync.Map // map[string]string
+
+	// reconstructedCache caches reconstructed objects to avoid repeated allocations.
+	// Key: resource key, Value: reconstructed map[string]interface{}
+	// Invalidated on Update/Delete. Thread-safe via sync.Map.
+	// NOTE: Cached objects are shared across callers - do not modify returned values.
+	reconstructedCache sync.Map // map[string]map[string]interface{}
 }
 
 // Essential metadata fields that are always stored
@@ -102,7 +108,11 @@ func (fs *FieldStore) List() []string {
 // The original object can be GC'd after this call.
 // Extracts: structure metadata (always), essential fields, and selected fields.
 // If no selected fields are set, extracts all values (backward compatible).
+// Invalidates any cached reconstruction for this key.
 func (fs *FieldStore) Update(key string, obj *unstructured.Unstructured) {
+	// Invalidate cache first (lock-free via sync.Map)
+	fs.reconstructedCache.Delete(key)
+
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 
@@ -128,16 +138,24 @@ func (fs *FieldStore) Update(key string, obj *unstructured.Unstructured) {
 	fs.data[key] = fields
 }
 
-// Delete removes a resource from the store
+// Delete removes a resource from the store.
+// Invalidates any cached reconstruction for this key.
 func (fs *FieldStore) Delete(key string) {
+	// Invalidate cache first (lock-free via sync.Map)
+	fs.reconstructedCache.Delete(key)
+
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 
 	delete(fs.data, key)
 }
 
-// Clear removes all resources from the store
+// Clear removes all resources from the store.
+// Also clears the reconstruction cache.
 func (fs *FieldStore) Clear() {
+	// Clear cache first (replace with new empty sync.Map)
+	fs.reconstructedCache = sync.Map{}
+
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 
@@ -271,17 +289,33 @@ func (fs *FieldStore) DetectStructureChange(oldFields, newFields map[string]inte
 // ReconstructObject rebuilds a partial object from stored fields.
 // Used for GetResourcesByKeys to return data to frontend.
 // Note: This returns only stored fields, not the full original object.
+//
+// Performance: Results are cached and reused until Update/Delete is called.
+// WARNING: The returned map is shared across callers - do not modify it.
 func (fs *FieldStore) ReconstructObject(key string) map[string]interface{} {
-	fs.mu.RLock()
-	defer fs.mu.RUnlock()
+	// Fast path: check cache first (lock-free via sync.Map)
+	if cached, ok := fs.reconstructedCache.Load(key); ok {
+		return cached.(map[string]interface{})
+	}
 
+	fs.mu.RLock()
 	fields, ok := fs.data[key]
 	if !ok {
+		fs.mu.RUnlock()
 		return nil
 	}
 
+	// Count non-structure fields to estimate map capacity
+	fieldCount := 0
+	for path := range fields {
+		if !strings.HasPrefix(path, "_struct:") {
+			fieldCount++
+		}
+	}
+
 	// Build a nested object from flat field paths
-	obj := make(map[string]interface{})
+	// Pre-allocate with estimated capacity (top-level keys ~10-20% of total fields)
+	obj := make(map[string]interface{}, fieldCount/5+4)
 
 	for path, value := range fields {
 		// Skip structure metadata (not part of the actual object)
@@ -290,8 +324,12 @@ func (fs *FieldStore) ReconstructObject(key string) map[string]interface{} {
 		}
 		setFieldByPath(obj, path, value)
 	}
+	fs.mu.RUnlock()
 
-	return obj
+	// Cache the result for subsequent calls
+	// Use LoadOrStore to handle concurrent reconstruction attempts
+	actual, _ := fs.reconstructedCache.LoadOrStore(key, obj)
+	return actual.(map[string]interface{})
 }
 
 // getFieldByPath retrieves a value from a nested map using dot notation.
@@ -316,17 +354,53 @@ func getFieldByPath(obj map[string]interface{}, path string) (interface{}, bool)
 	return current, true
 }
 
+// pathPartsPool reduces allocations for path splitting in setFieldByPath.
+// Each []string slice is reused for parsing dot-separated paths.
+var pathPartsPool = sync.Pool{
+	New: func() interface{} {
+		// Pre-allocate for typical path depth (e.g., "spec.containers.0.ports.0.containerPort")
+		parts := make([]string, 0, 8)
+		return &parts
+	},
+}
+
 // setFieldByPath sets a value in a nested structure using dot notation.
 // Handles both maps and arrays - numeric path segments create array indices.
 func setFieldByPath(obj map[string]interface{}, path string, value interface{}) {
-	parts := strings.Split(path, ".")
-	if len(parts) == 0 {
+	if path == "" {
 		return
 	}
+
+	// Get a slice from the pool and split path into it
+	partsPtr := pathPartsPool.Get().(*[]string)
+	parts := (*partsPtr)[:0] // Reset length, keep capacity
+
+	// Manual split to avoid allocation from strings.Split
+	start := 0
+	for i := 0; i <= len(path); i++ {
+		if i == len(path) || path[i] == '.' {
+			if i > start {
+				parts = append(parts, path[start:i])
+			}
+			start = i + 1
+		}
+	}
+
+	if len(parts) == 0 {
+		*partsPtr = parts
+		pathPartsPool.Put(partsPtr)
+		return
+	}
+
 	setNestedValue(obj, parts, value)
+
+	// Return to pool
+	*partsPtr = parts
+	pathPartsPool.Put(partsPtr)
 }
 
 // setNestedValue recursively sets a value in a nested map/array structure.
+// Optimized to minimize allocations by pre-sizing maps and arrays.
 func setNestedValue(current map[string]interface{}, parts []string, value interface{}) {
 	for i := 0; i < len(parts); i++ {
 		part := parts[i]
@@ -342,24 +416,21 @@ func setNestedValue(current map[string]interface{}, parts []string, value interf
 
 		if isNumericIndex(nextPart) {
 			// Next part is array index, ensure current[part] is an array
-			arr := ensureArray(current, part)
 			idx, _ := strconv.Atoi(nextPart)
 
-			// Ensure array has enough elements
-			for len(arr) <= idx {
-				arr = append(arr, nil)
-			}
-			current[part] = arr // Update in case append reallocated
+			// Get or create array with sufficient capacity
+			arr := ensureArrayWithCapacity(current, part, idx+1)
 
 			// Check if we're setting a leaf value or nested structure
 			if i+2 < len(parts) {
 				// More path segments after index - ensure element is a map
 				if arr[idx] == nil {
-					arr[idx] = make(map[string]interface{})
+					// Pre-allocate with small capacity for nested object
+					arr[idx] = make(map[string]interface{}, 4)
 				}
 				elemMap, ok := arr[idx].(map[string]interface{})
 				if !ok {
-					elemMap = make(map[string]interface{})
+					elemMap = make(map[string]interface{}, 4)
 					arr[idx] = elemMap
 				}
 				current = elemMap
@@ -372,11 +443,12 @@ func setNestedValue(current map[string]interface{}, parts []string, value interf
 		} else {
 			// Next part is a key, ensure current[part] is a map
 			if current[part] == nil {
-				current[part] = make(map[string]interface{})
+				// Pre-allocate with small capacity for nested object
+				current[part] = make(map[string]interface{}, 4)
 			}
 			nextMap, ok := current[part].(map[string]interface{})
 			if !ok {
-				nextMap = make(map[string]interface{})
+				nextMap = make(map[string]interface{}, 4)
 				current[part] = nextMap
 			}
 			current = nextMap
@@ -384,12 +456,22 @@ func setNestedValue(current map[string]interface{}, parts []string, value interf
 	}
 }
 
-// ensureArray ensures the value at key is a slice, creating one if needed.
-func ensureArray(m map[string]interface{}, key string) []interface{} {
+// ensureArrayWithCapacity ensures the value at key is a slice with at least minLen elements.
+// Creates or extends the array as needed, minimizing reallocations.
+func ensureArrayWithCapacity(m map[string]interface{}, key string, minLen int) []interface{} {
 	if arr, ok := m[key].([]interface{}); ok {
+		// Extend if needed
+		if len(arr) < minLen {
+			// Grow to exact size needed (we know the final size)
+			for len(arr) < minLen {
+				arr = append(arr, nil)
+			}
+			m[key] = arr
+		}
 		return arr
 	}
-	arr := make([]interface{}, 0)
+	// Create new array with exact capacity needed
+	arr := make([]interface{}, minLen)
 	m[key] = arr
 	return arr
 }

--- a/internal/kube/fieldstore.go
+++ b/internal/kube/fieldstore.go
@@ -25,9 +25,17 @@ type FieldStore struct {
 
 	// essentialFields are always extracted (metadata)
 	essentialFields []string
+
+	// stringPool interns frequently repeated string values to reduce memory.
+	// e.g., status.phase = "Running" is stored once, referenced by all pods.
+	stringPool sync.Map // map[string]string
 }
 
 // Essential metadata fields that are always stored
+// NOTE: metadata.annotations is EXCLUDED to reduce memory usage.
+// Annotations like "kubectl.kubernetes.io/last-applied-configuration" can be
+// very large (entire pod spec as JSON). If specific annotations are needed,
+// users can select them in DFT - they'll be added to selectedFields.
 var defaultEssentialFields = []string{
 	"metadata.name",
 	"metadata.namespace",
@@ -35,7 +43,7 @@ var defaultEssentialFields = []string{
 	"metadata.resourceVersion",
 	"metadata.creationTimestamp",
 	"metadata.labels",
-	"metadata.annotations",
+	// "metadata.annotations", // REMOVED: causes WebView memory explosion (2GB+ for 6k pods)
 	"metadata.ownerReferences",
 	"metadata.deletionTimestamp",
 	"metadata.finalizers",
@@ -92,15 +100,30 @@ func (fs *FieldStore) List() []string {
 
 // Update extracts and stores field values from a full Kubernetes object.
 // The original object can be GC'd after this call.
-// Extracts: all leaf values (primitives), structure metadata (array lengths, map keys).
+// Extracts: structure metadata (always), essential fields, and selected fields.
+// If no selected fields are set, extracts all values (backward compatible).
 func (fs *FieldStore) Update(key string, obj *unstructured.Unstructured) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 
 	fields := make(map[string]interface{})
 
-	// Extract ALL values (structure metadata + leaf values) with deep copy
-	extractAllValues(obj.Object, "", fields)
+	// Build extraction set: essential + selected fields
+	extractSet := make(map[string]struct{})
+	for _, f := range fs.essentialFields {
+		extractSet[f] = struct{}{}
+	}
+	for _, f := range fs.selectedFields {
+		extractSet[f] = struct{}{}
+	}
+
+	// If no fields specified, fall back to extracting all (backward compatible)
+	if len(extractSet) == 0 {
+		extractAllValues(obj.Object, "", fields, fs.internString)
+	} else {
+		// Extract structure metadata (always) + specified fields only
+		extractSelectiveValues(obj.Object, "", fields, extractSet, fs.internString)
+	}
 
 	fs.data[key] = fields
 }
@@ -146,6 +169,23 @@ func (fs *FieldStore) Count() int {
 	defer fs.mu.RUnlock()
 
 	return len(fs.data)
+}
+
+// internString returns a canonical string from the pool.
+// If the string is not in the pool, it's added and returned.
+// This reduces memory by sharing identical strings across resources.
+// Only interns short strings (<=64 chars) to avoid pool bloat from unique long values.
+func (fs *FieldStore) internString(s string) string {
+	// Don't intern very long strings (likely unique values like UIDs, timestamps)
+	if len(s) > 64 {
+		return s
+	}
+
+	if interned, ok := fs.stringPool.Load(s); ok {
+		return interned.(string)
+	}
+	fs.stringPool.Store(s, s)
+	return s
 }
 
 // GetMaxArrayLength returns the maximum array length at a given path across all resources.
@@ -364,7 +404,8 @@ func isNumericIndex(s string) bool {
 // - Structure metadata (_struct: prefix) for tree detection
 // - All primitive/leaf values (strings, numbers, bools) with deep copy
 // - Map keys and array lengths
-func extractAllValues(obj interface{}, prefix string, fields map[string]interface{}) {
+// intern is an optional function to intern repeated strings for memory efficiency.
+func extractAllValues(obj interface{}, prefix string, fields map[string]interface{}, intern func(string) string) {
 	switch v := obj.(type) {
 	case map[string]interface{}:
 		// Store map keys for this level (for tree detection)
@@ -382,7 +423,7 @@ func extractAllValues(obj interface{}, prefix string, fields map[string]interfac
 			if prefix != "" {
 				childPath = prefix + "." + k
 			}
-			extractAllValues(val, childPath, fields)
+			extractAllValues(val, childPath, fields, intern)
 		}
 
 	case []interface{}:
@@ -392,13 +433,90 @@ func extractAllValues(obj interface{}, prefix string, fields map[string]interfac
 		// Recurse into array elements with index in path
 		for i, elem := range v {
 			childPath := prefix + "." + strconv.Itoa(i)
-			extractAllValues(elem, childPath, fields)
+			extractAllValues(elem, childPath, fields, intern)
 		}
 
-	case string, bool, int, int64, float64, nil:
+	case string:
+		// Intern string values to reduce memory for repeated values
+		if prefix != "" {
+			fields[prefix] = intern(v)
+		}
+
+	case bool, int, int64, float64, nil:
 		// Store primitive values directly (these are already safe copies)
 		if prefix != "" {
 			fields[prefix] = v
 		}
 	}
+}
+
+// extractSelectiveValues extracts structure metadata (always) and selected field values only.
+// This significantly reduces memory usage by not storing unneeded leaf values.
+// Structure metadata (_struct:*) is always extracted for tree building.
+// Leaf values are only extracted if the path matches or is under a selected field.
+// intern is an optional function to intern repeated strings for memory efficiency.
+func extractSelectiveValues(obj interface{}, prefix string, fields map[string]interface{}, extractSet map[string]struct{}, intern func(string) string) {
+	switch v := obj.(type) {
+	case map[string]interface{}:
+		// Store map keys for this level (for tree detection) - ALWAYS
+		if prefix != "" {
+			keys := make([]string, 0, len(v))
+			for k := range v {
+				keys = append(keys, k)
+			}
+			fields["_struct:"+prefix+".keys"] = keys
+		}
+
+		// Recurse into children
+		for k, val := range v {
+			childPath := k
+			if prefix != "" {
+				childPath = prefix + "." + k
+			}
+			extractSelectiveValues(val, childPath, fields, extractSet, intern)
+		}
+
+	case []interface{}:
+		// Store array length - ALWAYS
+		fields["_struct:"+prefix+".len"] = len(v)
+
+		// Recurse into array elements with index in path
+		for i, elem := range v {
+			childPath := prefix + "." + strconv.Itoa(i)
+			extractSelectiveValues(elem, childPath, fields, extractSet, intern)
+		}
+
+	case string:
+		// Store string values ONLY if path should be extracted, intern for memory efficiency
+		if prefix != "" && shouldExtractPath(prefix, extractSet) {
+			fields[prefix] = intern(v)
+		}
+
+	case bool, int, int64, float64, nil:
+		// Store primitive values ONLY if path should be extracted
+		if prefix != "" && shouldExtractPath(prefix, extractSet) {
+			fields[prefix] = v
+		}
+	}
+}
+
+// shouldExtractPath checks if a path should have its value extracted.
+// Returns true if:
+// 1. Exact match: path is in extractSet
+// 2. Child of selected: a prefix of path is in extractSet (e.g., "metadata.labels.app" when "metadata.labels" is selected)
+func shouldExtractPath(path string, extractSet map[string]struct{}) bool {
+	// Exact match
+	if _, ok := extractSet[path]; ok {
+		return true
+	}
+
+	// Check if any selected field is a prefix of this path
+	// e.g., if "metadata.labels" is selected, extract "metadata.labels.app"
+	for selected := range extractSet {
+		if strings.HasPrefix(path, selected+".") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/kube/fieldstore.go
+++ b/internal/kube/fieldstore.go
@@ -532,16 +532,17 @@ func extractAllValues(obj interface{}, prefix string, fields map[string]interfac
 	}
 }
 
-// extractSelectiveValues extracts structure metadata (always) and selected field values only.
+// extractSelectiveValues extracts structure metadata and selected field values only.
 // This significantly reduces memory usage by not storing unneeded leaf values.
-// Structure metadata (_struct:*) is always extracted for tree building.
+// Structure metadata (_struct:*) is only extracted for paths that are on the way to
+// or under selected fields, preventing memory explosion from deeply nested structures.
 // Leaf values are only extracted if the path matches or is under a selected field.
 // intern is an optional function to intern repeated strings for memory efficiency.
 func extractSelectiveValues(obj interface{}, prefix string, fields map[string]interface{}, extractSet map[string]struct{}, intern func(string) string) {
 	switch v := obj.(type) {
 	case map[string]interface{}:
-		// Store map keys for this level (for tree detection) - ALWAYS
-		if prefix != "" {
+		// Store map keys only if this path is relevant to extractSet
+		if prefix != "" && isUnderExtractPath(prefix, extractSet) {
 			keys := make([]string, 0, len(v))
 			for k := range v {
 				keys = append(keys, k)
@@ -559,8 +560,10 @@ func extractSelectiveValues(obj interface{}, prefix string, fields map[string]in
 		}
 
 	case []interface{}:
-		// Store array length - ALWAYS
-		fields["_struct:"+prefix+".len"] = len(v)
+		// Store array length only if this path is relevant to extractSet
+		if isUnderExtractPath(prefix, extractSet) {
+			fields["_struct:"+prefix+".len"] = len(v)
+		}
 
 		// Recurse into array elements with index in path
 		for i, elem := range v {
@@ -595,6 +598,37 @@ func shouldExtractPath(path string, extractSet map[string]struct{}) bool {
 	// Check if any selected field is a prefix of this path
 	// e.g., if "metadata.labels" is selected, extract "metadata.labels.app"
 	for selected := range extractSet {
+		if strings.HasPrefix(path, selected+".") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUnderExtractPath checks if a path is relevant for structure metadata storage.
+// Returns true if:
+// 1. Exact match: path is in extractSet
+// 2. Ancestor: path is a prefix of any extractSet entry (need to traverse through this path)
+// 3. Descendant: any extractSet entry is a prefix of path (we're under a selected field)
+//
+// This limits structure metadata (_struct:*.keys, _struct:*.len) to only paths
+// that are on the way to or under selected fields, preventing memory explosion
+// from deeply nested structures like spec.containers[].env[].
+func isUnderExtractPath(path string, extractSet map[string]struct{}) bool {
+	// Exact match
+	if _, ok := extractSet[path]; ok {
+		return true
+	}
+
+	pathWithDot := path + "."
+
+	for selected := range extractSet {
+		// Check if path is an ancestor of selected (e.g., path="spec" and selected="spec.nodeName")
+		if strings.HasPrefix(selected, pathWithDot) {
+			return true
+		}
+		// Check if path is a descendant of selected (e.g., path="metadata.labels.app" and selected="metadata.labels")
 		if strings.HasPrefix(path, selected+".") {
 			return true
 		}

--- a/internal/kube/fieldstore.go
+++ b/internal/kube/fieldstore.go
@@ -332,28 +332,6 @@ func (fs *FieldStore) ReconstructObject(key string) map[string]interface{} {
 	return actual.(map[string]interface{})
 }
 
-// getFieldByPath retrieves a value from a nested map using dot notation.
-// e.g., "metadata.name" retrieves obj["metadata"]["name"]
-func getFieldByPath(obj map[string]interface{}, path string) (interface{}, bool) {
-	parts := strings.Split(path, ".")
-	current := interface{}(obj)
-
-	for _, part := range parts {
-		switch v := current.(type) {
-		case map[string]interface{}:
-			val, ok := v[part]
-			if !ok {
-				return nil, false
-			}
-			current = val
-		default:
-			return nil, false
-		}
-	}
-
-	return current, true
-}
-
 // pathPartsPool reduces allocations for path splitting in setFieldByPath.
 // Each []string slice is reused for parsing dot-separated paths.
 var pathPartsPool = sync.Pool{

--- a/internal/kube/fieldstore.go
+++ b/internal/kube/fieldstore.go
@@ -1,0 +1,404 @@
+package kube
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// FieldStore stores extracted field values for resources to reduce memory usage.
+// Instead of storing full Kubernetes objects, only essential metadata,
+// structure info (array lengths, map keys), and selected fields are stored.
+type FieldStore struct {
+	mu sync.RWMutex
+
+	// data stores field values per resource key
+	// key: "namespace/name" or "name" for cluster-scoped
+	// value: map[fieldPath]interface{}
+	data map[string]map[string]interface{}
+
+	// selectedFields are the field paths selected by the user for display
+	selectedFields []string
+
+	// essentialFields are always extracted (metadata)
+	essentialFields []string
+}
+
+// Essential metadata fields that are always stored
+var defaultEssentialFields = []string{
+	"metadata.name",
+	"metadata.namespace",
+	"metadata.uid",
+	"metadata.resourceVersion",
+	"metadata.creationTimestamp",
+	"metadata.labels",
+	"metadata.annotations",
+	"metadata.ownerReferences",
+	"metadata.deletionTimestamp",
+	"metadata.finalizers",
+}
+
+// NewFieldStore creates a new FieldStore instance
+func NewFieldStore() *FieldStore {
+	return &FieldStore{
+		data:            make(map[string]map[string]interface{}),
+		selectedFields:  make([]string, 0),
+		essentialFields: defaultEssentialFields,
+	}
+}
+
+// Get returns all stored field values for a resource
+func (fs *FieldStore) Get(key string) map[string]interface{} {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if fields, ok := fs.data[key]; ok {
+		// Return a copy to prevent external modification
+		result := make(map[string]interface{}, len(fields))
+		for k, v := range fields {
+			result[k] = v
+		}
+		return result
+	}
+	return nil
+}
+
+// GetField returns a specific field value for a resource
+func (fs *FieldStore) GetField(key, fieldPath string) (interface{}, bool) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if fields, ok := fs.data[key]; ok {
+		val, exists := fields[fieldPath]
+		return val, exists
+	}
+	return nil, false
+}
+
+// List returns all resource keys in the store
+func (fs *FieldStore) List() []string {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	keys := make([]string, 0, len(fs.data))
+	for k := range fs.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Update extracts and stores field values from a full Kubernetes object.
+// The original object can be GC'd after this call.
+// Extracts: all leaf values (primitives), structure metadata (array lengths, map keys).
+func (fs *FieldStore) Update(key string, obj *unstructured.Unstructured) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	fields := make(map[string]interface{})
+
+	// Extract ALL values (structure metadata + leaf values) with deep copy
+	extractAllValues(obj.Object, "", fields)
+
+	fs.data[key] = fields
+}
+
+// Delete removes a resource from the store
+func (fs *FieldStore) Delete(key string) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	delete(fs.data, key)
+}
+
+// Clear removes all resources from the store
+func (fs *FieldStore) Clear() {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	fs.data = make(map[string]map[string]interface{})
+}
+
+// SetSelectedFields updates the list of fields to extract.
+// Existing data is NOT re-extracted; new updates will use the new field list.
+func (fs *FieldStore) SetSelectedFields(fields []string) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	fs.selectedFields = fields
+}
+
+// GetSelectedFields returns the current selected fields
+func (fs *FieldStore) GetSelectedFields() []string {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	result := make([]string, len(fs.selectedFields))
+	copy(result, fs.selectedFields)
+	return result
+}
+
+// Count returns the number of resources in the store
+func (fs *FieldStore) Count() int {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	return len(fs.data)
+}
+
+// GetMaxArrayLength returns the maximum array length at a given path across all resources.
+// Used for tree building to determine how many index nodes to create.
+// path is a dot-separated path like "spec.containers" or "spec.containers.0.ports".
+func (fs *FieldStore) GetMaxArrayLength(path string) int {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	structKey := "_struct:" + path + ".len"
+	maxLen := 0
+
+	for _, fields := range fs.data {
+		if val, ok := fields[structKey]; ok {
+			if length, ok := val.(int); ok && length > maxLen {
+				maxLen = length
+			}
+		}
+	}
+
+	return maxLen
+}
+
+// GetDistinctMapKeys returns all unique map keys at a given path across all resources.
+// Used for tree building to create map key nodes.
+// path is a dot-separated path like "metadata.labels" or "metadata.annotations".
+func (fs *FieldStore) GetDistinctMapKeys(path string) []string {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	structKey := "_struct:" + path + ".keys"
+	exists := make(map[string]struct{})
+	var keys []string
+
+	for _, fields := range fs.data {
+		if val, ok := fields[structKey]; ok {
+			if keyList, ok := val.([]string); ok {
+				for _, k := range keyList {
+					if _, found := exists[k]; !found {
+						exists[k] = struct{}{}
+						keys = append(keys, k)
+					}
+				}
+			}
+		}
+	}
+
+	return keys
+}
+
+// DetectStructureChange compares structure metadata between two field maps.
+// Returns true if structure has changed (array lengths or map keys differ).
+func (fs *FieldStore) DetectStructureChange(oldFields, newFields map[string]interface{}) bool {
+	// Check structure metadata prefixed with "_struct:"
+	for k, newVal := range newFields {
+		if !strings.HasPrefix(k, "_struct:") {
+			continue
+		}
+
+		oldVal, exists := oldFields[k]
+		if !exists {
+			return true // new structure field
+		}
+
+		if !reflect.DeepEqual(oldVal, newVal) {
+			return true // structure changed
+		}
+	}
+
+	// Check if any structure fields were removed
+	for k := range oldFields {
+		if !strings.HasPrefix(k, "_struct:") {
+			continue
+		}
+		if _, exists := newFields[k]; !exists {
+			return true // structure field removed
+		}
+	}
+
+	return false
+}
+
+// ReconstructObject rebuilds a partial object from stored fields.
+// Used for GetResourcesByKeys to return data to frontend.
+// Note: This returns only stored fields, not the full original object.
+func (fs *FieldStore) ReconstructObject(key string) map[string]interface{} {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	fields, ok := fs.data[key]
+	if !ok {
+		return nil
+	}
+
+	// Build a nested object from flat field paths
+	obj := make(map[string]interface{})
+
+	for path, value := range fields {
+		// Skip structure metadata (not part of the actual object)
+		if strings.HasPrefix(path, "_struct:") {
+			continue
+		}
+		setFieldByPath(obj, path, value)
+	}
+
+	return obj
+}
+
+// getFieldByPath retrieves a value from a nested map using dot notation.
+// e.g., "metadata.name" retrieves obj["metadata"]["name"]
+func getFieldByPath(obj map[string]interface{}, path string) (interface{}, bool) {
+	parts := strings.Split(path, ".")
+	current := interface{}(obj)
+
+	for _, part := range parts {
+		switch v := current.(type) {
+		case map[string]interface{}:
+			val, ok := v[part]
+			if !ok {
+				return nil, false
+			}
+			current = val
+		default:
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+// setFieldByPath sets a value in a nested structure using dot notation.
+// Handles both maps and arrays - numeric path segments create array indices.
+func setFieldByPath(obj map[string]interface{}, path string, value interface{}) {
+	parts := strings.Split(path, ".")
+	if len(parts) == 0 {
+		return
+	}
+	setNestedValue(obj, parts, value)
+}
+
+// setNestedValue recursively sets a value in a nested map/array structure.
+func setNestedValue(current map[string]interface{}, parts []string, value interface{}) {
+	for i := 0; i < len(parts); i++ {
+		part := parts[i]
+		isLast := i == len(parts)-1
+
+		if isLast {
+			current[part] = value
+			return
+		}
+
+		// Look ahead to next part to determine structure type
+		nextPart := parts[i+1]
+
+		if isNumericIndex(nextPart) {
+			// Next part is array index, ensure current[part] is an array
+			arr := ensureArray(current, part)
+			idx, _ := strconv.Atoi(nextPart)
+
+			// Ensure array has enough elements
+			for len(arr) <= idx {
+				arr = append(arr, nil)
+			}
+			current[part] = arr // Update in case append reallocated
+
+			// Check if we're setting a leaf value or nested structure
+			if i+2 < len(parts) {
+				// More path segments after index - ensure element is a map
+				if arr[idx] == nil {
+					arr[idx] = make(map[string]interface{})
+				}
+				elemMap, ok := arr[idx].(map[string]interface{})
+				if !ok {
+					elemMap = make(map[string]interface{})
+					arr[idx] = elemMap
+				}
+				current = elemMap
+			} else {
+				// Index is second-to-last, set value directly in array
+				arr[idx] = value
+				return
+			}
+			i++ // Skip the index part we just processed
+		} else {
+			// Next part is a key, ensure current[part] is a map
+			if current[part] == nil {
+				current[part] = make(map[string]interface{})
+			}
+			nextMap, ok := current[part].(map[string]interface{})
+			if !ok {
+				nextMap = make(map[string]interface{})
+				current[part] = nextMap
+			}
+			current = nextMap
+		}
+	}
+}
+
+// ensureArray ensures the value at key is a slice, creating one if needed.
+func ensureArray(m map[string]interface{}, key string) []interface{} {
+	if arr, ok := m[key].([]interface{}); ok {
+		return arr
+	}
+	arr := make([]interface{}, 0)
+	m[key] = arr
+	return arr
+}
+
+// isNumericIndex returns true if s represents an array index (non-negative integer).
+func isNumericIndex(s string) bool {
+	_, err := strconv.Atoi(s)
+	return err == nil
+}
+
+// extractAllValues extracts ALL values from a Kubernetes object:
+// - Structure metadata (_struct: prefix) for tree detection
+// - All primitive/leaf values (strings, numbers, bools) with deep copy
+// - Map keys and array lengths
+func extractAllValues(obj interface{}, prefix string, fields map[string]interface{}) {
+	switch v := obj.(type) {
+	case map[string]interface{}:
+		// Store map keys for this level (for tree detection)
+		if prefix != "" {
+			keys := make([]string, 0, len(v))
+			for k := range v {
+				keys = append(keys, k)
+			}
+			fields["_struct:"+prefix+".keys"] = keys
+		}
+
+		// Recurse into children
+		for k, val := range v {
+			childPath := k
+			if prefix != "" {
+				childPath = prefix + "." + k
+			}
+			extractAllValues(val, childPath, fields)
+		}
+
+	case []interface{}:
+		// Store array length
+		fields["_struct:"+prefix+".len"] = len(v)
+
+		// Recurse into array elements with index in path
+		for i, elem := range v {
+			childPath := prefix + "." + strconv.Itoa(i)
+			extractAllValues(elem, childPath, fields)
+		}
+
+	case string, bool, int, int64, float64, nil:
+		// Store primitive values directly (these are already safe copies)
+		if prefix != "" {
+			fields[prefix] = v
+		}
+	}
+}

--- a/internal/kube/fieldstore_test.go
+++ b/internal/kube/fieldstore_test.go
@@ -161,8 +161,10 @@ var _ = Describe("FieldStore", func() {
 	})
 
 	Describe("Structure metadata extraction", func() {
-		It("should extract array lengths", func() {
+		It("should extract array lengths for selected fields", func() {
 			key := "default/test-pod"
+			// Set selected fields to include spec.containers so structure metadata is extracted
+			fs.SetSelectedFields([]string{"spec.containers"})
 			fs.Update(key, testObj)
 
 			fields := fs.Get(key)
@@ -170,15 +172,32 @@ var _ = Describe("FieldStore", func() {
 			Expect(fields["_struct:spec.containers.len"]).To(Equal(2))
 		})
 
-		It("should extract map keys", func() {
+		It("should extract map keys for selected fields", func() {
 			key := "default/test-pod"
+			// Set selected fields to include spec.* so structure metadata for spec is extracted
+			fs.SetSelectedFields([]string{"spec.containers", "spec.nodeName"})
 			fs.Update(key, testObj)
 
 			fields := fs.Get(key)
-			// metadata level should have keys
+			// spec level should have keys since it's an ancestor of selected fields
 			specKeys, ok := fields["_struct:spec.keys"].([]string)
 			Expect(ok).To(BeTrue())
 			Expect(specKeys).To(ContainElements("containers", "nodeName"))
+		})
+
+		It("should NOT extract structure metadata for non-selected paths", func() {
+			key := "default/test-pod"
+			// Only essential fields are selected (metadata.*)
+			// spec.* is not selected, so its structure metadata should NOT be stored
+			fs.Update(key, testObj)
+
+			fields := fs.Get(key)
+			// spec.containers structure metadata should NOT exist
+			_, hasSpecContainersLen := fields["_struct:spec.containers.len"]
+			Expect(hasSpecContainersLen).To(BeFalse())
+			// But metadata structure should exist (essential fields)
+			_, hasMetadataKeys := fields["_struct:metadata.keys"]
+			Expect(hasMetadataKeys).To(BeTrue())
 		})
 	})
 
@@ -232,6 +251,9 @@ var _ = Describe("FieldStore", func() {
 
 	Describe("GetMaxArrayLength", func() {
 		It("should return max array length across all resources", func() {
+			// Set selected fields to include spec.containers so structure metadata is extracted
+			fs.SetSelectedFields([]string{"spec.containers"})
+
 			// Create objects with different container counts
 			pod1 := &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -268,6 +290,8 @@ var _ = Describe("FieldStore", func() {
 		})
 
 		It("should return 0 for non-existent path", func() {
+			// Set selected fields to include spec.containers to store some structure metadata
+			fs.SetSelectedFields([]string{"spec.containers"})
 			fs.Update("default/test-pod", testObj)
 
 			maxLen := fs.GetMaxArrayLength("spec.nonexistent")

--- a/internal/kube/fieldstore_test.go
+++ b/internal/kube/fieldstore_test.go
@@ -1,0 +1,442 @@
+package kube
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("FieldStore", func() {
+	var (
+		fs      *FieldStore
+		testObj *unstructured.Unstructured
+	)
+
+	BeforeEach(func() {
+		fs = NewFieldStore()
+
+		testObj = &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":              "test-pod",
+					"namespace":         "default",
+					"uid":               "abc-123",
+					"resourceVersion":   "12345",
+					"creationTimestamp": "2024-01-01T00:00:00Z",
+					"labels": map[string]interface{}{
+						"app": "nginx",
+						"env": "prod",
+					},
+					"annotations": map[string]interface{}{
+						"note": "test annotation",
+					},
+					"ownerReferences": []interface{}{
+						map[string]interface{}{
+							"kind": "ReplicaSet",
+							"name": "test-rs",
+						},
+					},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx:1.19",
+							"ports": []interface{}{
+								map[string]interface{}{
+									"containerPort": float64(80),
+								},
+							},
+						},
+						map[string]interface{}{
+							"name":  "sidecar",
+							"image": "busybox",
+						},
+					},
+					"nodeName": "node-1",
+				},
+				"status": map[string]interface{}{
+					"phase": "Running",
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":   "Ready",
+							"status": "True",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	Describe("Basic operations", func() {
+		It("should store and retrieve essential fields", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			fields := fs.Get(key)
+			Expect(fields).NotTo(BeNil())
+			Expect(fields["metadata.name"]).To(Equal("test-pod"))
+			Expect(fields["metadata.namespace"]).To(Equal("default"))
+			Expect(fields["metadata.uid"]).To(Equal("abc-123"))
+		})
+
+		It("should return nil for non-existent key", func() {
+			fields := fs.Get("nonexistent/key")
+			Expect(fields).To(BeNil())
+		})
+
+		It("should delete resources", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+			Expect(fs.Get(key)).NotTo(BeNil())
+
+			fs.Delete(key)
+			Expect(fs.Get(key)).To(BeNil())
+		})
+
+		It("should list all keys", func() {
+			fs.Update("ns1/pod1", testObj)
+			fs.Update("ns2/pod2", testObj)
+
+			keys := fs.List()
+			Expect(keys).To(HaveLen(2))
+			Expect(keys).To(ContainElements("ns1/pod1", "ns2/pod2"))
+		})
+
+		It("should clear all data", func() {
+			fs.Update("ns1/pod1", testObj)
+			fs.Update("ns2/pod2", testObj)
+			Expect(fs.Count()).To(Equal(2))
+
+			fs.Clear()
+			Expect(fs.Count()).To(Equal(0))
+		})
+	})
+
+	Describe("GetField", func() {
+		It("should retrieve specific field values", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			val, found := fs.GetField(key, "metadata.name")
+			Expect(found).To(BeTrue())
+			Expect(val).To(Equal("test-pod"))
+		})
+
+		It("should return false for non-existent field", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			_, found := fs.GetField(key, "nonexistent.field")
+			Expect(found).To(BeFalse())
+		})
+	})
+
+	Describe("Field extraction", func() {
+		It("should extract all leaf values at full paths", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			fields := fs.Get(key)
+			// All leaf values are stored at their full path
+			Expect(fields["spec.nodeName"]).To(Equal("node-1"))
+			Expect(fields["status.phase"]).To(Equal("Running"))
+		})
+
+		It("should extract nested map values at full paths", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			fields := fs.Get(key)
+			// Labels are stored as individual keys, not as a nested map
+			Expect(fields["metadata.labels.app"]).To(Equal("nginx"))
+			Expect(fields["metadata.labels.env"]).To(Equal("prod"))
+		})
+	})
+
+	Describe("Structure metadata extraction", func() {
+		It("should extract array lengths", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			fields := fs.Get(key)
+			// spec.containers is an array of 2 elements
+			Expect(fields["_struct:spec.containers.len"]).To(Equal(2))
+		})
+
+		It("should extract map keys", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			fields := fs.Get(key)
+			// metadata level should have keys
+			specKeys, ok := fields["_struct:spec.keys"].([]string)
+			Expect(ok).To(BeTrue())
+			Expect(specKeys).To(ContainElements("containers", "nodeName"))
+		})
+	})
+
+	Describe("DetectStructureChange", func() {
+		It("should detect array length changes", func() {
+			oldFields := map[string]interface{}{
+				"_struct:spec.containers.len": 2,
+			}
+			newFields := map[string]interface{}{
+				"_struct:spec.containers.len": 3,
+			}
+
+			changed := fs.DetectStructureChange(oldFields, newFields)
+			Expect(changed).To(BeTrue())
+		})
+
+		It("should detect new structure fields", func() {
+			oldFields := map[string]interface{}{}
+			newFields := map[string]interface{}{
+				"_struct:spec.volumes.len": 1,
+			}
+
+			changed := fs.DetectStructureChange(oldFields, newFields)
+			Expect(changed).To(BeTrue())
+		})
+
+		It("should detect removed structure fields", func() {
+			oldFields := map[string]interface{}{
+				"_struct:spec.volumes.len": 1,
+			}
+			newFields := map[string]interface{}{}
+
+			changed := fs.DetectStructureChange(oldFields, newFields)
+			Expect(changed).To(BeTrue())
+		})
+
+		It("should return false when structure unchanged", func() {
+			oldFields := map[string]interface{}{
+				"_struct:spec.containers.len": 2,
+				"metadata.name":               "test",
+			}
+			newFields := map[string]interface{}{
+				"_struct:spec.containers.len": 2,
+				"metadata.name":               "test-changed",
+			}
+
+			changed := fs.DetectStructureChange(oldFields, newFields)
+			Expect(changed).To(BeFalse())
+		})
+	})
+
+	Describe("GetMaxArrayLength", func() {
+		It("should return max array length across all resources", func() {
+			// Create objects with different container counts
+			pod1 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "pod-1", "namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"name": "c1"},
+						},
+					},
+				},
+			}
+			pod2 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "pod-2", "namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"name": "c1"},
+							map[string]interface{}{"name": "c2"},
+							map[string]interface{}{"name": "c3"},
+						},
+					},
+				},
+			}
+
+			fs.Update("default/pod-1", pod1)
+			fs.Update("default/pod-2", pod2)
+
+			maxLen := fs.GetMaxArrayLength("spec.containers")
+			Expect(maxLen).To(Equal(3))
+		})
+
+		It("should return 0 for non-existent path", func() {
+			fs.Update("default/test-pod", testObj)
+
+			maxLen := fs.GetMaxArrayLength("spec.nonexistent")
+			Expect(maxLen).To(Equal(0))
+		})
+
+		It("should return 0 for empty store", func() {
+			maxLen := fs.GetMaxArrayLength("spec.containers")
+			Expect(maxLen).To(Equal(0))
+		})
+	})
+
+	Describe("GetDistinctMapKeys", func() {
+		It("should return all unique map keys across resources", func() {
+			// Create objects with different labels
+			pod1 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "pod-1", "namespace": "default",
+						"labels": map[string]interface{}{
+							"app": "nginx",
+							"env": "prod",
+						},
+					},
+				},
+			}
+			pod2 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "pod-2", "namespace": "default",
+						"labels": map[string]interface{}{
+							"app":     "redis",
+							"version": "1.0",
+						},
+					},
+				},
+			}
+
+			fs.Update("default/pod-1", pod1)
+			fs.Update("default/pod-2", pod2)
+
+			keys := fs.GetDistinctMapKeys("metadata.labels")
+			Expect(keys).To(ContainElements("app", "env", "version"))
+		})
+
+		It("should return empty slice for non-existent path", func() {
+			fs.Update("default/test-pod", testObj)
+
+			keys := fs.GetDistinctMapKeys("spec.nonexistent")
+			Expect(keys).To(BeEmpty())
+		})
+
+		It("should return empty slice for empty store", func() {
+			keys := fs.GetDistinctMapKeys("metadata.labels")
+			Expect(keys).To(BeEmpty())
+		})
+	})
+
+	Describe("ReconstructObject", func() {
+		It("should rebuild nested object from fields", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			obj := fs.ReconstructObject(key)
+			Expect(obj).NotTo(BeNil())
+
+			// Check nested structure is preserved
+			metadata, ok := obj["metadata"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(metadata["name"]).To(Equal("test-pod"))
+			Expect(metadata["namespace"]).To(Equal("default"))
+		})
+
+		It("should reconstruct arrays correctly", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			obj := fs.ReconstructObject(key)
+			Expect(obj).NotTo(BeNil())
+
+			// Check spec.containers is reconstructed as an array
+			spec, ok := obj["spec"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			containers, ok := spec["containers"].([]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(containers).To(HaveLen(2))
+
+			// Check first container
+			c0, ok := containers[0].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(c0["name"]).To(Equal("nginx"))
+			Expect(c0["image"]).To(Equal("nginx:1.19"))
+
+			// Check second container
+			c1, ok := containers[1].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(c1["name"]).To(Equal("sidecar"))
+			Expect(c1["image"]).To(Equal("busybox"))
+		})
+
+		It("should reconstruct nested arrays correctly", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			obj := fs.ReconstructObject(key)
+			spec, ok := obj["spec"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			containers, ok := spec["containers"].([]interface{})
+			Expect(ok).To(BeTrue())
+
+			// Check ports array in first container
+			c0 := containers[0].(map[string]interface{})
+			ports, ok := c0["ports"].([]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(ports).To(HaveLen(1))
+
+			port0 := ports[0].(map[string]interface{})
+			Expect(port0["containerPort"]).To(Equal(float64(80)))
+		})
+
+		It("should exclude structure metadata from reconstruction", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			obj := fs.ReconstructObject(key)
+			// Structure metadata should not appear in reconstructed object
+			for k := range obj {
+				Expect(k).NotTo(HavePrefix("_struct:"))
+			}
+		})
+
+		It("should return nil for non-existent key", func() {
+			obj := fs.ReconstructObject("nonexistent")
+			Expect(obj).To(BeNil())
+		})
+	})
+
+	Describe("Concurrent access", func() {
+		It("should handle concurrent reads and writes safely", func() {
+			done := make(chan bool, 10)
+
+			// Writers
+			for i := 0; i < 5; i++ {
+				go func(id int) {
+					defer GinkgoRecover()
+					for j := 0; j < 100; j++ {
+						key := "default/pod-" + string(rune('a'+id))
+						fs.Update(key, testObj)
+						fs.SetSelectedFields([]string{"status.phase"})
+					}
+					done <- true
+				}(i)
+			}
+
+			// Readers
+			for i := 0; i < 5; i++ {
+				go func() {
+					defer GinkgoRecover()
+					for j := 0; j < 100; j++ {
+						_ = fs.List()
+						_ = fs.Count()
+						_ = fs.Get("default/pod-a")
+						_, _ = fs.GetField("default/pod-a", "metadata.name")
+						_ = fs.ReconstructObject("default/pod-a")
+					}
+					done <- true
+				}()
+			}
+
+			// Wait for all goroutines
+			for i := 0; i < 10; i++ {
+				<-done
+			}
+		})
+	})
+})

--- a/internal/kube/fieldstore_test.go
+++ b/internal/kube/fieldstore_test.go
@@ -1,6 +1,8 @@
 package kube
 
 import (
+	"reflect"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -337,6 +339,94 @@ var _ = Describe("FieldStore", func() {
 			Expect(ok).To(BeTrue())
 			Expect(metadata["name"]).To(Equal("test-pod"))
 			Expect(metadata["namespace"]).To(Equal("default"))
+		})
+
+		It("should cache reconstructed objects for subsequent calls", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			// First call builds and caches
+			obj1 := fs.ReconstructObject(key)
+			Expect(obj1).NotTo(BeNil())
+
+			// Second call should return the same cached object (same pointer)
+			obj2 := fs.ReconstructObject(key)
+			Expect(obj2).NotTo(BeNil())
+
+			// Verify it's the same object (pointer equality via reflect)
+			// Maps cannot be compared directly in Go, so we use reflect.ValueOf().Pointer()
+			ptr1 := reflect.ValueOf(obj1).Pointer()
+			ptr2 := reflect.ValueOf(obj2).Pointer()
+			Expect(ptr1).To(Equal(ptr2), "Expected same pointer for cached objects")
+		})
+
+		It("should invalidate cache on Update", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			// Get cached object
+			obj1 := fs.ReconstructObject(key)
+			Expect(obj1).NotTo(BeNil())
+
+			// Update the resource (invalidates cache)
+			updatedObj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":      "test-pod-updated",
+						"namespace": "default",
+					},
+				},
+			}
+			fs.Update(key, updatedObj)
+
+			// Get new object (should be rebuilt)
+			obj2 := fs.ReconstructObject(key)
+			Expect(obj2).NotTo(BeNil())
+
+			// Should be a different object with updated data
+			metadata, ok := obj2["metadata"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(metadata["name"]).To(Equal("test-pod-updated"))
+
+			// Original cached object should still have old data
+			oldMetadata, ok := obj1["metadata"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(oldMetadata["name"]).To(Equal("test-pod"))
+		})
+
+		It("should invalidate cache on Delete", func() {
+			key := "default/test-pod"
+			fs.Update(key, testObj)
+
+			// Get cached object
+			obj1 := fs.ReconstructObject(key)
+			Expect(obj1).NotTo(BeNil())
+
+			// Delete the resource (invalidates cache)
+			fs.Delete(key)
+
+			// Should return nil now
+			obj2 := fs.ReconstructObject(key)
+			Expect(obj2).To(BeNil())
+		})
+
+		It("should invalidate all caches on Clear", func() {
+			// Add multiple resources
+			fs.Update("default/pod-1", testObj)
+			fs.Update("default/pod-2", testObj)
+
+			// Cache both
+			obj1 := fs.ReconstructObject("default/pod-1")
+			obj2 := fs.ReconstructObject("default/pod-2")
+			Expect(obj1).NotTo(BeNil())
+			Expect(obj2).NotTo(BeNil())
+
+			// Clear all
+			fs.Clear()
+
+			// Both should return nil now
+			Expect(fs.ReconstructObject("default/pod-1")).To(BeNil())
+			Expect(fs.ReconstructObject("default/pod-2")).To(BeNil())
 		})
 
 		It("should reconstruct arrays correctly", func() {

--- a/internal/kube/fieldstore_test.go
+++ b/internal/kube/fieldstore_test.go
@@ -135,12 +135,14 @@ var _ = Describe("FieldStore", func() {
 	})
 
 	Describe("Field extraction", func() {
-		It("should extract all leaf values at full paths", func() {
+		It("should extract selected fields at full paths", func() {
 			key := "default/test-pod"
+			// Set selected fields before Update to extract non-essential fields
+			fs.SetSelectedFields([]string{"spec.nodeName", "status.phase"})
 			fs.Update(key, testObj)
 
 			fields := fs.Get(key)
-			// All leaf values are stored at their full path
+			// Selected leaf values are stored at their full path
 			Expect(fields["spec.nodeName"]).To(Equal("node-1"))
 			Expect(fields["status.phase"]).To(Equal("Running"))
 		})
@@ -339,6 +341,8 @@ var _ = Describe("FieldStore", func() {
 
 		It("should reconstruct arrays correctly", func() {
 			key := "default/test-pod"
+			// Set selected fields to extract container data
+			fs.SetSelectedFields([]string{"spec.containers"})
 			fs.Update(key, testObj)
 
 			obj := fs.ReconstructObject(key)
@@ -366,6 +370,8 @@ var _ = Describe("FieldStore", func() {
 
 		It("should reconstruct nested arrays correctly", func() {
 			key := "default/test-pod"
+			// Set selected fields to extract container data including ports
+			fs.SetSelectedFields([]string{"spec.containers"})
 			fs.Update(key, testObj)
 
 			obj := fs.ReconstructObject(key)
@@ -437,6 +443,65 @@ var _ = Describe("FieldStore", func() {
 			for i := 0; i < 10; i++ {
 				<-done
 			}
+		})
+	})
+
+	Context("String interning", func() {
+		It("should intern identical string values", func() {
+			// Create multiple pods with the same status.phase value
+			for i := 0; i < 100; i++ {
+				pod := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":      "pod-" + string(rune('a'+i%26)),
+							"namespace": "default",
+						},
+						"status": map[string]interface{}{
+							"phase": "Running", // Same value across all pods
+						},
+					},
+				}
+				fs.SetSelectedFields([]string{"status.phase"})
+				fs.Update("default/pod-"+string(rune('a'+i%26)), pod)
+			}
+
+			// Verify all pods have the same interned value
+			var phaseValue interface{}
+			for i := 0; i < 26; i++ {
+				fields := fs.Get("default/pod-" + string(rune('a'+i)))
+				if fields == nil {
+					continue
+				}
+				if val, ok := fields["status.phase"]; ok {
+					if phaseValue == nil {
+						phaseValue = val
+					} else {
+						// All interned strings should be identical (same pointer)
+						Expect(val).To(Equal(phaseValue))
+					}
+				}
+			}
+		})
+
+		It("should not intern long strings (>64 chars)", func() {
+			longValue := "this-is-a-very-long-string-that-should-not-be-interned-because-it-exceeds-64-characters"
+			// Use labels instead of annotations (annotations removed from essential fields)
+			pod := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":      "test-pod",
+						"namespace": "default",
+						"labels": map[string]interface{}{
+							"long-label": longValue,
+						},
+					},
+				},
+			}
+			fs.Update("default/test-pod", pod)
+
+			fields := fs.Get("default/test-pod")
+			Expect(fields).NotTo(BeNil())
+			Expect(fields["metadata.labels.long-label"]).To(Equal(longValue))
 		})
 	})
 })

--- a/internal/kube/fieldstore_test.go
+++ b/internal/kube/fieldstore_test.go
@@ -619,3 +619,110 @@ var _ = Describe("FieldStore", func() {
 		})
 	})
 })
+
+var _ = Describe("isUnderExtractPath", func() {
+	var extractSet map[string]struct{}
+
+	BeforeEach(func() {
+		extractSet = map[string]struct{}{
+			"metadata.labels": {},
+			"spec.nodeName":   {},
+			"spec.containers": {},
+			"status.phase":    {},
+		}
+	})
+
+	Context("exact match", func() {
+		It("returns true for path in extractSet", func() {
+			Expect(isUnderExtractPath("metadata.labels", extractSet)).To(BeTrue())
+			Expect(isUnderExtractPath("spec.nodeName", extractSet)).To(BeTrue())
+			Expect(isUnderExtractPath("spec.containers", extractSet)).To(BeTrue())
+			Expect(isUnderExtractPath("status.phase", extractSet)).To(BeTrue())
+		})
+	})
+
+	Context("ancestor path (path is prefix of selected)", func() {
+		It("returns true when path is ancestor of selected field", func() {
+			// "spec" is ancestor of "spec.nodeName" and "spec.containers"
+			Expect(isUnderExtractPath("spec", extractSet)).To(BeTrue())
+			// "metadata" is ancestor of "metadata.labels"
+			Expect(isUnderExtractPath("metadata", extractSet)).To(BeTrue())
+		})
+
+		It("returns true for root-level ancestor", func() {
+			// "status" is ancestor of "status.phase"
+			Expect(isUnderExtractPath("status", extractSet)).To(BeTrue())
+		})
+	})
+
+	Context("descendant path (selected is prefix of path)", func() {
+		It("returns true when path is under selected field", func() {
+			// "metadata.labels.app" is under "metadata.labels"
+			Expect(isUnderExtractPath("metadata.labels.app", extractSet)).To(BeTrue())
+			Expect(isUnderExtractPath("metadata.labels.env", extractSet)).To(BeTrue())
+		})
+
+		It("returns true for array element paths under selected", func() {
+			// "spec.containers.0" is under "spec.containers"
+			Expect(isUnderExtractPath("spec.containers.0", extractSet)).To(BeTrue())
+			Expect(isUnderExtractPath("spec.containers.0.name", extractSet)).To(BeTrue())
+			Expect(isUnderExtractPath("spec.containers.0.image", extractSet)).To(BeTrue())
+		})
+
+		It("returns true for deeply nested paths under selected", func() {
+			// Deep nesting under spec.containers
+			Expect(isUnderExtractPath("spec.containers.0.env.0.valueFrom.secretKeyRef.name", extractSet)).To(BeTrue())
+		})
+	})
+
+	Context("unrelated path", func() {
+		It("returns false for completely unrelated paths", func() {
+			// "spec.volumes" has no relation to extractSet
+			Expect(isUnderExtractPath("spec.volumes", extractSet)).To(BeFalse())
+			Expect(isUnderExtractPath("spec.volumes.0.name", extractSet)).To(BeFalse())
+			// "metadata.annotations" not selected
+			Expect(isUnderExtractPath("metadata.annotations", extractSet)).To(BeFalse())
+			Expect(isUnderExtractPath("metadata.annotations.key", extractSet)).To(BeFalse())
+		})
+
+		It("returns false for partial string matches (not path prefix)", func() {
+			// "spec.node" is NOT ancestor of "spec.nodeName" (no dot boundary)
+			Expect(isUnderExtractPath("spec.node", extractSet)).To(BeFalse())
+			// "metadata.label" is NOT ancestor of "metadata.labels"
+			Expect(isUnderExtractPath("metadata.label", extractSet)).To(BeFalse())
+			// "status.phas" is NOT ancestor of "status.phase"
+			Expect(isUnderExtractPath("status.phas", extractSet)).To(BeFalse())
+		})
+
+		It("returns false for sibling paths", func() {
+			// "spec.serviceAccount" is sibling, not related to selected paths
+			Expect(isUnderExtractPath("spec.serviceAccount", extractSet)).To(BeFalse())
+			// "metadata.name" is sibling of "metadata.labels"
+			Expect(isUnderExtractPath("metadata.name", extractSet)).To(BeFalse())
+		})
+	})
+
+	Context("edge cases", func() {
+		It("handles empty extractSet", func() {
+			emptySet := map[string]struct{}{}
+			Expect(isUnderExtractPath("any.path", emptySet)).To(BeFalse())
+			Expect(isUnderExtractPath("metadata.labels", emptySet)).To(BeFalse())
+		})
+
+		It("handles single-segment paths", func() {
+			singleSet := map[string]struct{}{"metadata": {}}
+			Expect(isUnderExtractPath("metadata", singleSet)).To(BeTrue())
+			Expect(isUnderExtractPath("metadata.name", singleSet)).To(BeTrue())
+			Expect(isUnderExtractPath("metadata.labels.app", singleSet)).To(BeTrue())
+			Expect(isUnderExtractPath("spec", singleSet)).To(BeFalse())
+		})
+
+		It("handles single entry extractSet", func() {
+			singleEntry := map[string]struct{}{"spec.containers": {}}
+			Expect(isUnderExtractPath("spec", singleEntry)).To(BeTrue())           // ancestor
+			Expect(isUnderExtractPath("spec.containers", singleEntry)).To(BeTrue()) // exact
+			Expect(isUnderExtractPath("spec.containers.0", singleEntry)).To(BeTrue()) // descendant
+			Expect(isUnderExtractPath("spec.nodeName", singleEntry)).To(BeFalse())  // sibling
+		})
+	})
+})

--- a/internal/kube/fieldstore_test.go
+++ b/internal/kube/fieldstore_test.go
@@ -719,10 +719,10 @@ var _ = Describe("isUnderExtractPath", func() {
 
 		It("handles single entry extractSet", func() {
 			singleEntry := map[string]struct{}{"spec.containers": {}}
-			Expect(isUnderExtractPath("spec", singleEntry)).To(BeTrue())           // ancestor
-			Expect(isUnderExtractPath("spec.containers", singleEntry)).To(BeTrue()) // exact
+			Expect(isUnderExtractPath("spec", singleEntry)).To(BeTrue())              // ancestor
+			Expect(isUnderExtractPath("spec.containers", singleEntry)).To(BeTrue())   // exact
 			Expect(isUnderExtractPath("spec.containers.0", singleEntry)).To(BeTrue()) // descendant
-			Expect(isUnderExtractPath("spec.nodeName", singleEntry)).To(BeFalse())  // sibling
+			Expect(isUnderExtractPath("spec.nodeName", singleEntry)).To(BeFalse())    // sibling
 		})
 	})
 })

--- a/internal/kube/keyonlystore.go
+++ b/internal/kube/keyonlystore.go
@@ -1,0 +1,122 @@
+package kube
+
+import (
+	"sync"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// KeyOnlyStore implements cache.Store but only stores keys, not full objects.
+// This drastically reduces memory usage by letting full Kubernetes objects be GC'd
+// after their field values are extracted to FieldStore.
+//
+// The informer's event handlers (AddFunc, UpdateFunc, DeleteFunc) still receive
+// full objects - they're passed directly from the API server response, not from the store.
+// This store is only used for:
+// - Tracking which keys exist (for ListKeys)
+// - Supporting HasSynced detection via Replace
+type KeyOnlyStore struct {
+	mu      sync.RWMutex
+	keys    map[string]struct{}
+	keyFunc cache.KeyFunc
+}
+
+// NewKeyOnlyStore creates a new KeyOnlyStore with the given key function.
+// Typically use cache.MetaNamespaceKeyFunc for Kubernetes objects.
+func NewKeyOnlyStore(keyFunc cache.KeyFunc) *KeyOnlyStore {
+	return &KeyOnlyStore{
+		keys:    make(map[string]struct{}),
+		keyFunc: keyFunc,
+	}
+}
+
+// Add implements cache.Store - only stores the key, discards the object
+func (s *KeyOnlyStore) Add(obj interface{}) error {
+	key, err := s.keyFunc(obj)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.keys[key] = struct{}{}
+	s.mu.Unlock()
+	return nil
+}
+
+// Update implements cache.Store - only stores the key, discards the object
+func (s *KeyOnlyStore) Update(obj interface{}) error {
+	return s.Add(obj) // Same behavior for key-only storage
+}
+
+// Delete implements cache.Store - removes the key
+func (s *KeyOnlyStore) Delete(obj interface{}) error {
+	key, err := s.keyFunc(obj)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	delete(s.keys, key)
+	s.mu.Unlock()
+	return nil
+}
+
+// List implements cache.Store - returns nil since we don't store objects
+// Use FieldStore.ReconstructObject for actual data retrieval
+func (s *KeyOnlyStore) List() []interface{} {
+	return nil
+}
+
+// ListKeys implements cache.Store - returns all stored keys
+func (s *KeyOnlyStore) ListKeys() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := make([]string, 0, len(s.keys))
+	for k := range s.keys {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Get implements cache.Store - returns nil since we don't store objects
+func (s *KeyOnlyStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	key, err := s.keyFunc(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return s.GetByKey(key)
+}
+
+// GetByKey implements cache.Store - returns nil but indicates if key exists
+func (s *KeyOnlyStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	s.mu.RLock()
+	_, exists = s.keys[key]
+	s.mu.RUnlock()
+	return nil, exists, nil
+}
+
+// Replace implements cache.Store - replaces all keys (called during initial List sync)
+func (s *KeyOnlyStore) Replace(list []interface{}, resourceVersion string) error {
+	newKeys := make(map[string]struct{}, len(list))
+	for _, obj := range list {
+		key, err := s.keyFunc(obj)
+		if err != nil {
+			continue
+		}
+		newKeys[key] = struct{}{}
+	}
+	s.mu.Lock()
+	s.keys = newKeys
+	s.mu.Unlock()
+	return nil
+}
+
+// Resync implements cache.Store - no-op for key-only store
+func (s *KeyOnlyStore) Resync() error {
+	return nil
+}
+
+// Count returns the number of keys in the store
+func (s *KeyOnlyStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.keys)
+}

--- a/internal/kube/node.go
+++ b/internal/kube/node.go
@@ -220,6 +220,16 @@ func CreateNodeTree(fieldTree map[string]*Field, objs []*unstructured.Unstructur
 	return result
 }
 
+// isNumericPath checks if a path segment is likely a numeric index.
+// This avoids calling strconv.Atoi and allocating error objects for non-numeric paths.
+func isNumericPath(path string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	// Check if the first character is a digit
+	return path[0] >= '0' && path[0] <= '9'
+}
+
 func getNestedValue(obj map[string]interface{}, paths ...string) (interface{}, bool, error) {
 	var current interface{} = obj
 
@@ -234,8 +244,13 @@ func getNestedValue(obj map[string]interface{}, paths ...string) (interface{}, b
 			} else {
 				return nil, false, fmt.Errorf("expected array for wildcard, got %T", current)
 			}
-		} else if index, err := strconv.Atoi(path); err == nil {
-			// for array nodes
+		} else if isNumericPath(path) {
+			// for array nodes - only try parsing if path looks like a number
+			index, err := strconv.Atoi(path)
+			if err != nil {
+				// Shouldn't happen since we pre-checked, but handle gracefully
+				return nil, false, fmt.Errorf("invalid index: %s", path)
+			}
 			if slice, ok := current.([]interface{}); ok {
 				if index >= len(slice) {
 					return nil, false, fmt.Errorf("index %d out of bounds", index)
@@ -327,6 +342,224 @@ func getDistinctKeys(mapPath []string, objs []*unstructured.Unstructured) []stri
 	}
 
 	return keys
+}
+
+// pathToString converts a path slice to dot-separated string for FieldStore lookup
+func pathToString(path []string) string {
+	return strings.Join(path, ".")
+}
+
+// CreateNodeTreeFromStore creates a node tree using FieldStore's structure metadata.
+// This is memory-efficient as it doesn't require full Kubernetes objects.
+func CreateNodeTreeFromStore(fieldTree map[string]*Field, fs *FieldStore, nodePrefix []string) map[string]*Node {
+	result := make(map[string]*Node)
+
+	for key, field := range fieldTree {
+		prefix := field.Prefix
+		if !comparePrefix(nodePrefix, field.Prefix) {
+			prefix = nodePrefix
+		}
+
+		childPrefix := append(prefix, key)
+		children := map[string]*Node(nil)
+
+		if field.IsArray() {
+			maxLength := fs.GetMaxArrayLength(pathToString(childPrefix))
+			children = make(map[string]*Node)
+
+			// Add wildcard node for non-empty arrays (before creating index nodes)
+			if maxLength > 0 && field.Children != nil {
+				wildcardChildren := CreateNodeTreeFromStore(field.Children, fs, append(childPrefix, "*"))
+				children["*"] = &Node{
+					field:     nil,
+					name:      "*",
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  wildcardChildren,
+				}
+			}
+
+			for i := 0; i < maxLength; i++ {
+				idx := strconv.Itoa(i)
+				grandChildren := map[string]*Node(nil)
+				if field.Children != nil {
+					grandChildren = CreateNodeTreeFromStore(field.Children, fs, append(childPrefix, idx))
+				}
+
+				children[idx] = &Node{
+					field:     nil,
+					name:      idx,
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  grandChildren,
+				}
+			}
+		} else if field.IsMap() {
+			keys := fs.GetDistinctMapKeys(pathToString(childPrefix))
+			children = make(map[string]*Node)
+
+			// Add wildcard node for maps with keys (select all keys)
+			if len(keys) > 0 {
+				children["*"] = &Node{
+					field:     nil,
+					name:      "*",
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  nil,
+				}
+			}
+
+			for _, mapKey := range keys {
+				grandChildren := map[string]*Node(nil)
+				if field.Children != nil {
+					grandChildren = CreateNodeTreeFromStore(field.Children, fs, append(childPrefix, mapKey))
+				}
+
+				children[mapKey] = &Node{
+					field:     nil,
+					name:      mapKey,
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  grandChildren,
+				}
+			}
+
+		} else if field.IsObject() {
+			children = CreateNodeTreeFromStore(field.Children, fs, childPrefix)
+		}
+
+		result[key] = &Node{
+			field:     field,
+			ancestors: prefix,
+			name:      key,
+			children:  children,
+		}
+	}
+
+	return result
+}
+
+// UpdateNodeTreeFromStore updates a node tree using FieldStore's structure metadata.
+// Preserves Expanded/Selected state from existing nodes.
+func UpdateNodeTreeFromStore(existing map[string]*Node, fieldTree map[string]*Field, fs *FieldStore, nodePrefix []string) map[string]*Node {
+	result := make(map[string]*Node)
+
+	for key, field := range fieldTree {
+		prefix := field.Prefix
+		if !comparePrefix(nodePrefix, field.Prefix) {
+			prefix = nodePrefix
+		}
+
+		childPrefix := append(prefix, key)
+		var children map[string]*Node
+
+		existingNode, exists := existing[key]
+		expanded := exists && existingNode.Expanded
+		selected := exists && existingNode.Selected
+
+		if field.IsArray() {
+			maxLength := fs.GetMaxArrayLength(pathToString(childPrefix))
+			children = make(map[string]*Node)
+
+			// Add wildcard node for non-empty arrays
+			if maxLength > 0 && field.Children != nil {
+				existingWildcardChildren := map[string]*Node{}
+				if exists && existingNode.children != nil && existingNode.children["*"] != nil {
+					existingWildcardChildren = existingNode.children["*"].children
+				}
+				wildcardChildren := UpdateNodeTreeFromStore(existingWildcardChildren, field.Children, fs, append(childPrefix, "*"))
+				children["*"] = &Node{
+					field:     nil,
+					name:      "*",
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  wildcardChildren,
+					Expanded:  exists && existingNode.children != nil && existingNode.children["*"] != nil && existingNode.children["*"].Expanded,
+					Selected:  exists && existingNode.children != nil && existingNode.children["*"] != nil && existingNode.children["*"].Selected,
+				}
+			}
+
+			for i := 0; i < maxLength; i++ {
+				idx := strconv.Itoa(i)
+				var grandChildren map[string]*Node
+
+				if field.Children != nil {
+					existingChildren := map[string]*Node{}
+					if exists && existingNode.children != nil && existingNode.children[idx] != nil {
+						existingChildren = existingNode.children[idx].children
+					}
+					grandChildren = UpdateNodeTreeFromStore(existingChildren, field.Children, fs, append(childPrefix, idx))
+				}
+
+				children[idx] = &Node{
+					field:     nil,
+					name:      idx,
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  grandChildren,
+					Expanded:  exists && existingNode.children != nil && existingNode.children[idx] != nil && existingNode.children[idx].Expanded,
+					Selected:  exists && existingNode.children != nil && existingNode.children[idx] != nil && existingNode.children[idx].Selected,
+				}
+			}
+		} else if field.IsMap() {
+			keys := fs.GetDistinctMapKeys(pathToString(childPrefix))
+			children = make(map[string]*Node)
+
+			// Add wildcard node for maps with keys
+			if len(keys) > 0 {
+				children["*"] = &Node{
+					field:     nil,
+					name:      "*",
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  nil,
+					Expanded:  exists && existingNode.children != nil && existingNode.children["*"] != nil && existingNode.children["*"].Expanded,
+					Selected:  exists && existingNode.children != nil && existingNode.children["*"] != nil && existingNode.children["*"].Selected,
+				}
+			}
+
+			for _, mapKey := range keys {
+				var grandChildren map[string]*Node
+
+				if field.Children != nil {
+					existingChildren := map[string]*Node{}
+					if exists && existingNode.children != nil {
+						if existingChild, ok := existingNode.children[mapKey]; ok {
+							existingChildren = existingChild.children
+						}
+					}
+					grandChildren = UpdateNodeTreeFromStore(existingChildren, field.Children, fs, append(childPrefix, mapKey))
+				}
+
+				children[mapKey] = &Node{
+					field:     nil,
+					name:      mapKey,
+					ancestors: childPrefix,
+					level:     field.Level + 1,
+					children:  grandChildren,
+					Expanded:  exists && existingNode.children != nil && existingNode.children[mapKey] != nil && existingNode.children[mapKey].Expanded,
+					Selected:  exists && existingNode.children != nil && existingNode.children[mapKey] != nil && existingNode.children[mapKey].Selected,
+				}
+			}
+		} else if field.IsObject() {
+			existingChildren := map[string]*Node{}
+			if exists {
+				existingChildren = existingNode.children
+			}
+			children = UpdateNodeTreeFromStore(existingChildren, field.Children, fs, childPrefix)
+		}
+
+		result[key] = &Node{
+			field:     field,
+			ancestors: prefix,
+			name:      key,
+			children:  children,
+			Expanded:  expanded,
+			Selected:  selected,
+		}
+	}
+
+	return result
 }
 
 // TODO: refactor, pull up traverse with create to function

--- a/internal/kube/node_test.go
+++ b/internal/kube/node_test.go
@@ -73,6 +73,9 @@ var _ = Describe("Node", func() {
 		})
 
 		It("should create nodes for array fields using FieldStore", func() {
+			// Set selected fields to include spec.containers so structure metadata is extracted
+			fs.SetSelectedFields([]string{"spec.containers"})
+
 			// Create a pod with containers array
 			pod := &unstructured.Unstructured{
 				Object: map[string]interface{}{

--- a/internal/kube/node_test.go
+++ b/internal/kube/node_test.go
@@ -64,4 +64,183 @@ var _ = Describe("Node", func() {
 			Expect(node.Pickable(objs)).To(BeFalse())
 		})
 	})
+
+	Describe("CreateNodeTreeFromStore", func() {
+		var fs *FieldStore
+
+		BeforeEach(func() {
+			fs = NewFieldStore()
+		})
+
+		It("should create nodes for array fields using FieldStore", func() {
+			// Create a pod with containers array
+			pod := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "test-pod", "namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"name": "c1"},
+							map[string]interface{}{"name": "c2"},
+						},
+					},
+				},
+			}
+			fs.Update("default/test-pod", pod)
+
+			// Create field tree with array field
+			fieldTree := map[string]*Field{
+				"spec": {
+					Name:   "spec",
+					Type:   "object",
+					Prefix: []string{},
+					Children: map[string]*Field{
+						"containers": {
+							Name:   "containers",
+							Type:   "[]Container",
+							Prefix: []string{"spec"},
+							Level:  1,
+						},
+					},
+				},
+			}
+
+			nodes := CreateNodeTreeFromStore(fieldTree, fs, []string{})
+			Expect(nodes).To(HaveKey("spec"))
+			Expect(nodes["spec"].children).To(HaveKey("containers"))
+
+			containersNode := nodes["spec"].children["containers"]
+			// Should have 2 index nodes plus wildcard
+			Expect(containersNode.children).To(HaveKey("0"))
+			Expect(containersNode.children).To(HaveKey("1"))
+		})
+
+		It("should create nodes for map fields using FieldStore", func() {
+			// Create pods with different labels
+			pod1 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "pod-1", "namespace": "default",
+						"labels": map[string]interface{}{
+							"app": "nginx",
+							"env": "prod",
+						},
+					},
+				},
+			}
+			pod2 := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "pod-2", "namespace": "default",
+						"labels": map[string]interface{}{
+							"app":     "redis",
+							"version": "1.0",
+						},
+					},
+				},
+			}
+			fs.Update("default/pod-1", pod1)
+			fs.Update("default/pod-2", pod2)
+
+			// Create field tree with map field
+			fieldTree := map[string]*Field{
+				"metadata": {
+					Name:   "metadata",
+					Type:   "object",
+					Prefix: []string{},
+					Children: map[string]*Field{
+						"labels": {
+							Name:   "labels",
+							Type:   "map[string]string",
+							Prefix: []string{"metadata"},
+							Level:  1,
+						},
+					},
+				},
+			}
+
+			nodes := CreateNodeTreeFromStore(fieldTree, fs, []string{})
+			Expect(nodes).To(HaveKey("metadata"))
+			Expect(nodes["metadata"].children).To(HaveKey("labels"))
+
+			labelsNode := nodes["metadata"].children["labels"]
+			// Should have all distinct keys
+			Expect(labelsNode.children).To(HaveKey("app"))
+			Expect(labelsNode.children).To(HaveKey("env"))
+			Expect(labelsNode.children).To(HaveKey("version"))
+		})
+
+		It("should work with empty FieldStore", func() {
+			fieldTree := map[string]*Field{
+				"spec": {
+					Name:   "spec",
+					Type:   "object",
+					Prefix: []string{},
+					Children: map[string]*Field{
+						"containers": {
+							Name:   "containers",
+							Type:   "[]Container",
+							Prefix: []string{"spec"},
+							Level:  1,
+						},
+					},
+				},
+			}
+
+			nodes := CreateNodeTreeFromStore(fieldTree, fs, []string{})
+			Expect(nodes).To(HaveKey("spec"))
+			containersNode := nodes["spec"].children["containers"]
+			// No index nodes when store is empty
+			Expect(containersNode.children).To(BeEmpty())
+		})
+	})
+
+	Describe("UpdateNodeTreeFromStore", func() {
+		var fs *FieldStore
+
+		BeforeEach(func() {
+			fs = NewFieldStore()
+		})
+
+		It("should preserve Expanded state when updating", func() {
+			pod := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "test-pod", "namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{"name": "c1"},
+						},
+					},
+				},
+			}
+			fs.Update("default/test-pod", pod)
+
+			fieldTree := map[string]*Field{
+				"spec": {
+					Name:   "spec",
+					Type:   "object",
+					Prefix: []string{},
+					Children: map[string]*Field{
+						"containers": {
+							Name:   "containers",
+							Type:   "[]Container",
+							Prefix: []string{"spec"},
+							Level:  1,
+						},
+					},
+				},
+			}
+
+			// Create initial tree
+			existingNodes := CreateNodeTreeFromStore(fieldTree, fs, []string{})
+			existingNodes["spec"].Expanded = true
+
+			// Update tree
+			updatedNodes := UpdateNodeTreeFromStore(existingNodes, fieldTree, fs, []string{})
+			Expect(updatedNodes["spec"].Expanded).To(BeTrue())
+		})
+	})
 })

--- a/internal/kube/resource.go
+++ b/internal/kube/resource.go
@@ -57,7 +57,8 @@ type ResourceController struct {
 	contextName string // optional, for GUI multi-context support
 	client      dynamic.Interface
 	gvr         schema.GroupVersionResource
-	store       cache.Store
+	store       cache.Store       // may be KeyOnlyStore (memory-efficient) or default store
+	keyStore    *KeyOnlyStore     // non-nil when using memory-efficient mode
 	emitCh      chan emitMsg
 	doneCh      chan struct{} // signals that controller is closed (for event consumers)
 	closed      atomic.Bool   // guards trySend to prevent sends after close
@@ -127,6 +128,120 @@ func (i *ResourceController) Objects() []*unstructured.Unstructured {
 	return objs
 }
 
+// SyncCallback is called synchronously for each object during initial sync.
+// This runs in the informer's goroutine, so there's no race condition.
+type SyncCallback func(eventType EventType, obj *unstructured.Unstructured)
+
+// InformWithKeyOnlyStore starts the informer with a memory-efficient KeyOnlyStore.
+// This is the recommended method for GUI usage where FieldStore handles data storage.
+// Objects are NOT retained in memory after event handlers process them.
+//
+// The onSync callback is called synchronously for each object during initial list sync.
+// This guarantees all initial objects are processed without race conditions.
+// After sync completes, ongoing events are emitted via WatchEvents() channel.
+func (i *ResourceController) InformWithKeyOnlyStore(onSync SyncCallback) (chan struct{}, error) {
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return i.client.Resource(i.gvr).Namespace("").List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return i.client.Resource(i.gvr).Namespace("").Watch(context.Background(), options)
+		},
+	}
+
+	// Use KeyOnlyStore instead of default store to avoid retaining full objects
+	keyStore := NewKeyOnlyStore(cache.MetaNamespaceKeyFunc)
+	i.keyStore = keyStore
+	i.store = keyStore
+
+	// Create DeltaFIFO with KeyOnlyStore as KnownObjects
+	fifo := cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
+		KnownObjects:          keyStore,
+		EmitDeltaTypeReplaced: true,
+	})
+
+	// Process function handles events and updates KeyOnlyStore
+	process := func(obj interface{}, isInInitialList bool) error {
+		deltas, ok := obj.(cache.Deltas)
+		if !ok {
+			return fmt.Errorf("expected Deltas, got %T", obj)
+		}
+
+		for _, delta := range deltas {
+			u, ok := delta.Object.(*unstructured.Unstructured)
+			if !ok {
+				continue
+			}
+
+			key, _ := cache.MetaNamespaceKeyFunc(u)
+
+			switch delta.Type {
+			case cache.Added, cache.Replaced, cache.Sync:
+				// Update KeyOnlyStore (only tracks keys)
+				keyStore.Add(u)
+				// Cache name for sorting
+				i.nameCacheMu.Lock()
+				i.nameCache[key] = u.GetName()
+				i.nameCacheMu.Unlock()
+
+				if isInInitialList && onSync != nil {
+					// During initial sync: call callback synchronously (no race condition)
+					onSync(EventAdded, u)
+				} else {
+					// After sync: emit via channel (may drop if buffer full)
+					i.trySend(emitMsg{Type: EventAdded, Obj: u})
+				}
+
+			case cache.Updated:
+				keyStore.Update(u)
+				i.nameCacheMu.Lock()
+				i.nameCache[key] = u.GetName()
+				i.nameCacheMu.Unlock()
+
+				if isInInitialList && onSync != nil {
+					onSync(EventModified, u)
+				} else {
+					i.trySend(emitMsg{Type: EventModified, Obj: u})
+				}
+
+			case cache.Deleted:
+				keyStore.Delete(u)
+				i.nameCacheMu.Lock()
+				delete(i.nameCache, key)
+				i.nameCacheMu.Unlock()
+
+				if isInInitialList && onSync != nil {
+					onSync(EventDeleted, u)
+				} else {
+					i.trySend(emitMsg{Type: EventDeleted, Obj: u})
+				}
+			}
+		}
+		return nil
+	}
+
+	cfg := &cache.Config{
+		Queue:            fifo,
+		ListerWatcher:    lw,
+		ObjectType:       &unstructured.Unstructured{},
+		FullResyncPeriod: 0, // No resync
+		Process:          process,
+	}
+
+	controller := cache.New(cfg)
+	stop := make(chan struct{})
+	go controller.Run(stop)
+
+	if !cache.WaitForCacheSync(stop, controller.HasSynced) {
+		close(stop)
+		return nil, fmt.Errorf("failed to sync cache")
+	}
+
+	return stop, nil
+}
+
+// Inform starts the informer with default cache.Store (legacy, for TUI compatibility).
+// Use InformWithKeyOnlyStore for memory-efficient GUI usage.
 func (i *ResourceController) Inform() (chan struct{}, error) {
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {

--- a/internal/kube/resource.go
+++ b/internal/kube/resource.go
@@ -20,19 +20,23 @@ import (
 
 // Event metrics for debugging memory leaks
 var (
-	eventsEmitted atomic.Int64
-	eventsDropped atomic.Int64
+	eventsEmitted  atomic.Int64
+	eventsDropped  atomic.Int64
+	syncProcessed  atomic.Int64 // items processed via onSync callback during initial list
+	trySendCalled  atomic.Int64 // items that went through trySend (isInInitialList=false)
 )
 
-// GetEventMetrics returns the current event metrics (emitted, dropped)
-func GetEventMetrics() (emitted, dropped int64) {
-	return eventsEmitted.Load(), eventsDropped.Load()
+// GetEventMetrics returns the current event metrics (emitted, dropped, syncProcessed, trySendCalled)
+func GetEventMetrics() (emitted, dropped, synced, trySent int64) {
+	return eventsEmitted.Load(), eventsDropped.Load(), syncProcessed.Load(), trySendCalled.Load()
 }
 
 // ResetEventMetrics resets the event counters to zero
 func ResetEventMetrics() {
 	eventsEmitted.Store(0)
 	eventsDropped.Store(0)
+	syncProcessed.Store(0)
+	trySendCalled.Store(0)
 }
 
 // EventType represents the type of watch event
@@ -186,9 +190,11 @@ func (i *ResourceController) InformWithKeyOnlyStore(onSync SyncCallback) (chan s
 
 				if isInInitialList && onSync != nil {
 					// During initial sync: call callback synchronously (no race condition)
+					syncProcessed.Add(1)
 					onSync(EventAdded, u)
 				} else {
 					// After sync: emit via channel (may drop if buffer full)
+					trySendCalled.Add(1)
 					i.trySend(emitMsg{Type: EventAdded, Obj: u})
 				}
 
@@ -199,8 +205,10 @@ func (i *ResourceController) InformWithKeyOnlyStore(onSync SyncCallback) (chan s
 				i.nameCacheMu.Unlock()
 
 				if isInInitialList && onSync != nil {
+					syncProcessed.Add(1)
 					onSync(EventModified, u)
 				} else {
+					trySendCalled.Add(1)
 					i.trySend(emitMsg{Type: EventModified, Obj: u})
 				}
 
@@ -211,8 +219,10 @@ func (i *ResourceController) InformWithKeyOnlyStore(onSync SyncCallback) (chan s
 				i.nameCacheMu.Unlock()
 
 				if isInInitialList && onSync != nil {
+					syncProcessed.Add(1)
 					onSync(EventDeleted, u)
 				} else {
+					trySendCalled.Add(1)
 					i.trySend(emitMsg{Type: EventDeleted, Obj: u})
 				}
 			}

--- a/internal/kube/resource.go
+++ b/internal/kube/resource.go
@@ -20,10 +20,10 @@ import (
 
 // Event metrics for debugging memory leaks
 var (
-	eventsEmitted  atomic.Int64
-	eventsDropped  atomic.Int64
-	syncProcessed  atomic.Int64 // items processed via onSync callback during initial list
-	trySendCalled  atomic.Int64 // items that went through trySend (isInInitialList=false)
+	eventsEmitted atomic.Int64
+	eventsDropped atomic.Int64
+	syncProcessed atomic.Int64 // items processed via onSync callback during initial list
+	trySendCalled atomic.Int64 // items that went through trySend (isInInitialList=false)
 )
 
 // GetEventMetrics returns the current event metrics (emitted, dropped, syncProcessed, trySendCalled)
@@ -61,8 +61,8 @@ type ResourceController struct {
 	contextName string // optional, for GUI multi-context support
 	client      dynamic.Interface
 	gvr         schema.GroupVersionResource
-	store       cache.Store       // may be KeyOnlyStore (memory-efficient) or default store
-	keyStore    *KeyOnlyStore     // non-nil when using memory-efficient mode
+	store       cache.Store   // may be KeyOnlyStore (memory-efficient) or default store
+	keyStore    *KeyOnlyStore // non-nil when using memory-efficient mode
 	emitCh      chan emitMsg
 	doneCh      chan struct{} // signals that controller is closed (for event consumers)
 	closed      atomic.Bool   // guards trySend to prevent sends after close
@@ -182,7 +182,7 @@ func (i *ResourceController) InformWithKeyOnlyStore(onSync SyncCallback) (chan s
 			switch delta.Type {
 			case cache.Added, cache.Replaced, cache.Sync:
 				// Update KeyOnlyStore (only tracks keys)
-				keyStore.Add(u)
+				_ = keyStore.Add(u)
 				// Cache name for sorting
 				i.nameCacheMu.Lock()
 				i.nameCache[key] = u.GetName()
@@ -199,7 +199,7 @@ func (i *ResourceController) InformWithKeyOnlyStore(onSync SyncCallback) (chan s
 				}
 
 			case cache.Updated:
-				keyStore.Update(u)
+				_ = keyStore.Update(u)
 				i.nameCacheMu.Lock()
 				i.nameCache[key] = u.GetName()
 				i.nameCacheMu.Unlock()
@@ -213,7 +213,7 @@ func (i *ResourceController) InformWithKeyOnlyStore(onSync SyncCallback) (chan s
 				}
 
 			case cache.Deleted:
-				keyStore.Delete(u)
+				_ = keyStore.Delete(u)
 				i.nameCacheMu.Lock()
 				delete(i.nameCache, key)
 				i.nameCacheMu.Unlock()


### PR DESCRIPTION
## Summary

- Implement memory-efficient informer with KeyOnlyStore (store only keys, not full objects)
- Add ReconstructObject caching with `sync.Map` and proper invalidation
- Implement delta updates (include fields in `resource:update` events)
- Fix structure metadata explosion by limiting `_struct:*.keys/len` to extractSet paths only
- Add progressive loading with `sync:progress` events

## Results

| Metric | Before | After | Target |
|--------|--------|-------|--------|
| Go Heap (5.6k pods) | 971 MB | 95 MB | 300 MB ✅ |
| Projected for 10k pods | ~1.8 GB | ~170 MB | 300 MB ✅ |
| extractSelectiveValues | 625 MB (85%) | 24 MB (40%) | - |
| pprof vs Process Gap | 30-40x | ~7x | Reasonable ✅ |

**Key finding**: Structure metadata explosion was the root cause. `extractSelectiveValues` stored `_struct:*.keys` and `_struct:*.len` for ALL nested paths, consuming 625MB. Adding `isUnderExtractPath` filter reduced this by **26x**.

## Test plan

- [x] Go tests: 49/49 passed
- [x] Frontend tests: 231/231 passed
- [x] Manual verification: 5,606 pods loaded in prodlive context
- [x] Memory profiling: Heap at 95MB, well under 300MB target

## Futureworks

- All memory problem is not solved yet, still 1.xG is used when shows 12k Pods for go backend. 
- To solve this, SQLite + Pull model would be used for data retrieving. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)